### PR TITLE
Remove -ErrorAction Stop from Install-Module cmdlet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.1] - 2017-03-23
+### Fixed error in !install-plugin command when installing plugins that had a dependency on the PoshBot module.
+
 ## [0.1.0] - 2017-03-21
 ### Added
 - Initial documentation for mkdocs

--- a/PoshBot/Plugins/Builtin/Builtin.psd1
+++ b/PoshBot/Plugins/Builtin/Builtin.psd1
@@ -12,7 +12,7 @@
 RootModule = 'Builtin.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.0'
+ModuleVersion = '0.2.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PoshBot/Plugins/Builtin/builtin.psm1
+++ b/PoshBot/Plugins/Builtin/builtin.psm1
@@ -269,13 +269,19 @@ function Install-Plugin {
             $mod = @(Get-Module -Name $Name -ListAvailable | Sort-Object -Property Version -Descending)[0]
         }
         if (-not $mod) {
-            if ($PSBoundParameters.ContainsKey('Version')) {
-                $onlineMod = Find-Module -Name $Name -Repository $bot.Configuration.PluginRepository -RequiredVersion $Version -ErrorAction SilentlyContinue
-            } else {
-                $onlineMod = Find-Module -Name $Name -Repository $bot.Configuration.PluginRepository -ErrorAction SilentlyContinue
+
+            # Attemp to find the module in our PS repository
+            $findParams = @{
+                Name = $Name
+                Repository = $bot.Configuration.PluginRepository
+                ErrorAction = 'SilentlyContinue'
             }
-            if ($onlineMod) {
-                $onlineMod | Install-Module -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+            if ($PSBoundParameters.ContainsKey('Version')) {
+                RequiredVersion = $Version
+            }
+
+            if ($onlineMod = Find-Module @findParams) {
+                $onlineMod | Install-Module -Scope CurrentUser -Force
 
                 if ($PSBoundParameters.ContainsKey('Version')) {
                     $mod = Get-Module -Name $Name -ListAvailable | Where-Object {$_.Version -eq $Version}

--- a/PoshBot/Plugins/Builtin/builtin.psm1
+++ b/PoshBot/Plugins/Builtin/builtin.psm1
@@ -275,7 +275,7 @@ function Install-Plugin {
                 $onlineMod = Find-Module -Name $Name -Repository $bot.Configuration.PluginRepository -ErrorAction SilentlyContinue
             }
             if ($onlineMod) {
-                $onlineMod | Install-Module -Scope CurrentUser -Force -ErrorAction Stop
+                $onlineMod | Install-Module -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
 
                 if ($PSBoundParameters.ContainsKey('Version')) {
                     $mod = Get-Module -Name $Name -ListAvailable | Where-Object {$_.Version -eq $Version}

--- a/PoshBot/PoshBot.psd1
+++ b/PoshBot/PoshBot.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PoshBot.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.0'
+ModuleVersion = '0.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
## Description
The `-ErrorAction Stop` switch in the `Install-Module` cmdlet of the `Install-Plugin` command was causing the command to fail when it didn't need to. We know that the `Configuration` module is installed as it is a dependency in PoshBot. Installing modules from the PSGallery that have a dependency on PoshBot therefore also have a dependency on the `Configuration` module.

## Related Issue
#18

## Motivation and Context
Fixes the problem with installing modules from the PSGallery that have a dependency on PoshBot.

## How Has This Been Tested?
1. Uninstalled all PoshBot modules from local system.
2. Installed the following modules via `!install-plugin` and ensured they were installed from the PSGallery without error.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
