### PR TITLE
Revise Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 
 FROM microsoft/nanoserver
 
-MAINTAINER devblackops
-
+LABEL maintainer="devblackops"
 LABEL description="PoshBot container for Slack"
 LABEL vendor="poshbotio"
 


### PR DESCRIPTION
The `MAINTAINER` keyword is deprecated and superseded by the `LABEL` keyword, see https://docs.docker.com/engine/reference/builder/#maintainer-deprecated