### PR TITLE
Add initial get-it-working stateful data functions

### DIFF
--- a/PoshBot/PoshBot.psd1
+++ b/PoshBot/PoshBot.psd1
@@ -71,7 +71,8 @@ ScriptsToProcess = @('PoshBotAttribute.ps1')
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
     'Get-PoshBot'
-    'Get-PoshBotConfiguration'
+    'Get-PoshBotConfiguration',
+    'Get-PoshBotStatefulData',
     'New-PoshBotAce'
     'New-PoshBotBackend'
     'New-PoshBotConfiguration'
@@ -82,6 +83,7 @@ FunctionsToExport = @(
     'New-PoshBotCardResponse'
     'New-PoshBotTextResponse'
     'Save-PoshBotConfiguration'
+    'Set-PoshBotStatefulData'
     'Start-PoshBot'
     'Stop-Poshbot'
 )

--- a/PoshBot/Public/Get-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Get-PoshBotStatefulData.ps1
@@ -38,7 +38,6 @@ function Get-PoshBotStatefulData {
         [string]$Scope = 'Module'
     )
     process {
-        $ParentPath = $pbc.ConfigurationDirectory
         if($Scope -eq 'Module') {
             $FileName = "$($poshbotcontext.Plugin).state"
         } else {

--- a/PoshBot/Public/Get-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Get-PoshBotStatefulData.ps1
@@ -41,11 +41,11 @@ function Get-PoshBotStatefulData {
     )
     process {
         if($Scope -eq 'Module') {
-            $FileName = "$($poshbotcontext.Plugin).state"
+            $FileName = "$($PoshBotContext.Plugin).state"
         } else {
             $FileName = "PoshbotGlobal.state"
         }
-        $Path = Join-Path $pbc.ConfigurationDirectory $FileName
+        $Path = Join-Path $PoshBotContext.ConfigurationDirectory $FileName
 
         if(-not (Test-Path $Path)) {
             Write-Verbose "Requested stateful data file not found: [$Path]"

--- a/PoshBot/Public/Get-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Get-PoshBotStatefulData.ps1
@@ -1,0 +1,63 @@
+
+function Get-PoshBotStatefulData {
+    <#
+    .SYNOPSIS
+        Get stateful data previously exported from a PoshBot command
+    .DESCRIPTION
+        Get stateful data previously exported from a PoshBot command
+
+        Reads data from the PoshBot ConfigurationDirectory.
+    .PARAMETER Name
+        If specified, retrieve only this property from the stateful data
+    .PARAMETER ValueOnly
+        If specified, return only the value of the specified property Name
+    .PARAMETER Scope
+        Get stateful data from this scope:
+            Module: Data scoped to this plugin 
+            Global: Data available to any Poshbot plugin
+    .EXAMPLE
+        $ModuleData = Get-PoshBotStatefulData
+
+        Get all stateful data for the PoshBot plugin this runs from
+    .EXAMPLE
+        $Something = Get-PoshBotStatefulData -Name 'Something' -ValueOnly -Scope Global
+
+        Set $Something to the value of the 'Something' property from Poshbot's global stateful data
+    .LINK
+        Set-PoshBotStatefulData
+    .LINK
+        Start-PoshBot
+    #>
+    [cmdletbinding()]
+    param(
+        [string]$Name = '*',
+
+        [switch]$ValueOnly,
+
+        [validateset('Global','Module')]
+        [string]$Scope = 'Module'
+    )
+    process {
+        $ParentPath = $pbc.ConfigurationDirectory
+        if($Scope -eq 'Module') {
+            $FileName = "$($poshbotcontext.Plugin).state"
+        } else {
+            $FileName = "PoshbotGlobal.state"
+        }
+        $Path = Join-Path $pbc.ConfigurationDirectory $FileName
+
+        if(-not (Test-Path $Path)) {
+            Write-Verbose "Requested stateful data file not found: [$Path]"
+            return
+        }
+        Write-Verbose "Getting stateful data from [$Path]"
+        $Output = Import-Clixml -Path $Path | Select-Object -Property $Name
+        if($ValueOnly)
+        {
+            $Output = $Output.${Name}
+        }
+        $Output
+    }
+}
+
+Export-ModuleMember -Function 'Get-PoshBotStatefulData'

--- a/PoshBot/Public/Get-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Get-PoshBotStatefulData.ps1
@@ -26,6 +26,8 @@ function Get-PoshBotStatefulData {
     .LINK
         Set-PoshBotStatefulData
     .LINK
+        Remove-PoshBotStatefulData
+    .LINK
         Start-PoshBot
     #>
     [cmdletbinding()]

--- a/PoshBot/Public/Remove-PoshbotStatefulData.ps1
+++ b/PoshBot/Public/Remove-PoshbotStatefulData.ps1
@@ -40,11 +40,11 @@ function Remove-PoshBotStatefulData {
     )
     process {
         if($Scope -eq 'Module') {
-            $FileName = "$($poshbotcontext.Plugin).state"
+            $FileName = "$($PoshBotContext.Plugin).state"
         } else {
             $FileName = "PoshbotGlobal.state"
         }
-        $Path = Join-Path $pbc.ConfigurationDirectory $FileName
+        $Path = Join-Path $PoshBotContext.ConfigurationDirectory $FileName
 
         if(-not (Test-Path $Path)) {
             return

--- a/PoshBot/Public/Remove-PoshbotStatefulData.ps1
+++ b/PoshBot/Public/Remove-PoshbotStatefulData.ps1
@@ -1,0 +1,60 @@
+﻿
+function Remove-PoshBotStatefulData {
+    <#
+    .SYNOPSIS
+        Remove existing stateful data
+    .DESCRIPTION
+        Remove existing stateful data
+    .PARAMETER Name
+        Property to remove from the stateful data file 
+    .PARAMETER Scope
+        Sets the scope of stateful data to remove:
+            Module: Remove stateful data from the current module's data
+            Global: Remove stateful data from the global PoshBot data
+    .PARAMETER Depth
+        Specifies how many levels of contained objects are included in the XML representation. The default value is 2
+    .EXAMPLE
+        PS C:\> Remove-PoshBotStatefulData -Name 'ToUse'
+
+        Removes the 'ToUse' property from stateful data for the PoshBot plugin you are currently running this from.
+    .EXAMPLE
+        PS C:\> Remove-PoshBotStatefulData -Name 'Something' -Scope Global
+
+        Removes the 'Something' property from PoshBot's global stateful data
+    .LINK
+        Get-PoshBotStatefulData
+    .LINK
+        Set-PoshBotStatefulData
+    .LINK
+        Start-PoshBot
+    #>
+    [cmdletbinding()]
+    param(
+        [parameter(Mandatory)]
+        [string[]]$Name,
+
+        [validateset('Global','Module')]
+        [string]$Scope = 'Module',
+
+        [int]$Depth = 2
+    )
+    process {
+        if($Scope -eq 'Module') {
+            $FileName = "$($poshbotcontext.Plugin).state"
+        } else {
+            $FileName = "PoshbotGlobal.state"
+        }
+        $Path = Join-Path $pbc.ConfigurationDirectory $FileName
+
+        if(-not (Test-Path $Path)) {
+            return
+        } else {
+            $ToWrite = Import-Clixml -Path $Path | Select-Object * -ExcludeProperty $Name
+        }
+
+        Export-Clixml -Path $Path -InputObject $ToWrite -Depth $Depth -Force
+        Write-Verbose -Message "Stateful data saved to [$Path]"
+    }
+}
+
+Export-ModuleMember -Function 'Remove-PoshBotStatefulData'

--- a/PoshBot/Public/Set-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Set-PoshBotStatefulData.ps1
@@ -30,6 +30,8 @@ function Set-PoshBotStatefulData {
     .LINK
         Get-PoshBotStatefulData
     .LINK
+        Remove-PoshBotStatefulData
+    .LINK
         Start-PoshBot
     #>
     [cmdletbinding()]
@@ -47,7 +49,6 @@ function Set-PoshBotStatefulData {
         [int]$Depth = 2
     )
     process {
-        $ParentPath = $pbc.ConfigurationDirectory
         if($Scope -eq 'Module') {
             $FileName = "$($poshbotcontext.Plugin).state"
         } else {
@@ -65,7 +66,7 @@ function Set-PoshBotStatefulData {
             If($Existing.PSObject.Properties.Name -contains $Name) {
                 Write-Verbose "Overwriting [$Name]`nCurrent value: [$($Existing.$Name | Out-String)])`nNew Value: [$($Value | Out-String)]"
             }
-            $Existing.$Name = $Value
+            Add-Member -InputObject $Existing -MemberType NoteProperty -Name $Name -Value $Value -Force
             $ToWrite = $Existing
         }
 

--- a/PoshBot/Public/Set-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Set-PoshBotStatefulData.ps1
@@ -1,0 +1,77 @@
+
+function Set-PoshBotStatefulData {
+    <#
+    .SYNOPSIS
+        Save stateful data to use in another PoshBot command
+    .DESCRIPTION
+        Save stateful data to use in another PoshBot command
+
+        Stores data in clixml format, in the PoshBot ConfigurationDirectory.
+        
+        If <Name> property exists in current stateful data file, it is overwritten
+    .PARAMETER Name
+        Property to add to the stateful data file 
+    .PARAMETER Value
+        Value to set for the Name property in the stateful data file
+    .PARAMETER Scope
+        Sets the scope of stateful data to set:
+            Module: Allow only this plugin to access the stateful data you save
+            Global: Allow any plugin to access the stateful data you save
+    .PARAMETER Depth
+        Specifies how many levels of contained objects are included in the XML representation. The default value is 2
+    .EXAMPLE
+        PS C:\> Set-PoshBotStatefulData -Name 'ToUse' -Value 'Later'
+
+        Adds a 'ToUse' property to the stateful data for the PoshBot plugin you are currently running this from.
+    .EXAMPLE
+        PS C:\> $Anything | Set-PoshBotStatefulData -Name 'Something' -Scope Global
+
+        Adds a 'Something' property to PoshBot's global stateful data, with the value of $Anything
+    .LINK
+        Get-PoshBotStatefulData
+    .LINK
+        Start-PoshBot
+    #>
+    [cmdletbinding()]
+    param(
+        [parameter(Mandatory)]
+        [string]$Name,
+
+        [parameter(ValueFromPipeline,
+                   Mandatory)]
+        [string]$Value,
+
+        [validateset('Global','Module')]
+        [string]$Scope = 'Module',
+
+        [int]$Depth = 2
+    )
+    process {
+        $ParentPath = $pbc.ConfigurationDirectory
+        if($Scope -eq 'Module') {
+            $FileName = "$($poshbotcontext.Plugin).state"
+        } else {
+            $FileName = "PoshbotGlobal.state"
+        }
+        $Path = Join-Path $pbc.ConfigurationDirectory $FileName
+
+        if(-not (Test-Path $Path)) {
+            $ToWrite = [pscustomobject]@{
+                $Name = $Value
+            }
+        } else {
+            $Existing = Import-Clixml -Path $Path
+            # TODO: Consider handling for -Force?
+            If($Existing.PSObject.Properties.Name -contains $Name) {
+                Write-Verbose "Overwriting [$Name]`nCurrent value: [$($Existing.$Name | Out-String)])`nNew Value: [$($Value | Out-String)]"
+            }
+            $Existing.$Name = $Value
+            $ToWrite = $Existing
+        }
+
+        Export-Clixml -Path $Path -InputObject $ToWrite -Depth $Depth -Force
+        Write-Verbose -Message "Stateful data saved to [$Path]"
+    }
+}
+
+Export-ModuleMember -Function 'Set-PoshBotStatefulData'

--- a/PoshBot/Public/Set-PoshBotStatefulData.ps1
+++ b/PoshBot/Public/Set-PoshBotStatefulData.ps1
@@ -50,11 +50,11 @@ function Set-PoshBotStatefulData {
     )
     process {
         if($Scope -eq 'Module') {
-            $FileName = "$($poshbotcontext.Plugin).state"
+            $FileName = "$($PoshBotContext.Plugin).state"
         } else {
             $FileName = "PoshbotGlobal.state"
         }
-        $Path = Join-Path $pbc.ConfigurationDirectory $FileName
+        $Path = Join-Path $PoshBotContext.ConfigurationDirectory $FileName
 
         if(-not (Test-Path $Path)) {
             $ToWrite = [pscustomobject]@{

--- a/Tests/Unit/Public/Get-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Get-PoshBotStatefulData.tests.ps1
@@ -1,0 +1,49 @@
+﻿
+InModuleScope PoshBot {
+    describe 'Get-PoshBotStatefulData' {
+        it 'Returns nothing if no file exists' {
+            $pbc = [pscustomobject]@{
+                ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests\Data)
+            }
+            Get-PoshBotStatefulData -Scope Module | Should BeNullorEmpty
+            Get-PoshBotStatefulData -Scope Global | Should BeNullorEmpty
+        }
+
+        # Set internal variables, create stateful files
+        $pbc = [pscustomobject]@{
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests\Data)
+        }
+        $poshbotcontext = [pscustomobject]@{
+            Plugin = 'TestPlugin'
+        }
+
+        $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
+        $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
+        [pscustomobject]@{
+            a = 'g'
+            b = $true
+        } | Export-Clixml -Path $globalfile
+        [pscustomobject]@{
+            a = 'm'
+        } | Export-Clixml -Path $modulefile
+
+        it 'Returns expected data if a file exists' {
+            $m = Get-PoshBotStatefulData -Scope Module
+            $m.a | Should Be 'm'
+            $m.psobject.properties.count | Should Be 1
+            
+            $g = Get-PoshBotStatefulData -Scope Global
+            $g.a | Should Be 'g'
+            $g.b | Should Be $True
+            @($g.psobject.properties).count | Should Be 2
+        }
+
+        it 'Supports ValueOnly' {
+            Get-PoshBotStatefulData -Scope Global -Name a -ValueOnly | Should be 'g'
+            Get-PoshBotStatefulData -Scope Module -Name a -ValueOnly | Should be 'm'
+        }
+
+        Remove-Item $globalfile -Force
+        Remove-Item $modulefile -Force
+    }
+}

--- a/Tests/Unit/Public/Get-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Get-PoshBotStatefulData.tests.ps1
@@ -1,22 +1,20 @@
 ﻿
 InModuleScope PoshBot {
     describe 'Get-PoshBotStatefulData' {
-        it 'Returns nothing if no file exists' {
-            $pbc = [pscustomobject]@{
-                ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests\Data)
-            }
-            Get-PoshBotStatefulData -Scope Module | Should BeNullorEmpty
-            Get-PoshBotStatefulData -Scope Global | Should BeNullorEmpty
-        }
-
-        # Set internal variables, create stateful files
+        # Define internal variables
         $pbc = [pscustomobject]@{
-            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests\Data)
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
         }
         $poshbotcontext = [pscustomobject]@{
             Plugin = 'TestPlugin'
         }
 
+        it 'Returns nothing if no file exists' {
+            Get-PoshBotStatefulData -Scope Module | Should BeNullorEmpty
+            Get-PoshBotStatefulData -Scope Global | Should BeNullorEmpty
+        }
+
+        # Create stateful files
         $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
         $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
         [pscustomobject]@{

--- a/Tests/Unit/Public/Get-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Get-PoshBotStatefulData.tests.ps1
@@ -2,11 +2,9 @@
 InModuleScope PoshBot {
     describe 'Get-PoshBotStatefulData' {
         # Define internal variables
-        $pbc = [pscustomobject]@{
-            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
-        }
         $poshbotcontext = [pscustomobject]@{
             Plugin = 'TestPlugin'
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
         }
 
         it 'Returns nothing if no file exists' {
@@ -15,8 +13,8 @@ InModuleScope PoshBot {
         }
 
         # Create stateful files
-        $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
-        $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
+        $globalfile = Join-Path $poshbotcontext.ConfigurationDirectory "PoshbotGlobal.state"
+        $modulefile = Join-Path $poshbotcontext.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
         [pscustomobject]@{
             a = 'g'
             b = $true

--- a/Tests/Unit/Public/Remove-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Remove-PoshBotStatefulData.tests.ps1
@@ -2,14 +2,12 @@
 InModuleScope PoshBot {
     describe 'Remove-PoshBotStatefulData' {
         # Define internal variables
-        $pbc = [pscustomobject]@{
-            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
-        }
         $poshbotcontext = [pscustomobject]@{
             Plugin = 'TestPlugin'
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
         }
-        $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
-        $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
+        $globalfile = Join-Path $poshbotcontext.ConfigurationDirectory "PoshbotGlobal.state"
+        $modulefile = Join-Path $poshbotcontext.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
         [pscustomobject]@{
             a = 'g'
             b = $true

--- a/Tests/Unit/Public/Remove-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Remove-PoshBotStatefulData.tests.ps1
@@ -1,0 +1,40 @@
+﻿
+InModuleScope PoshBot {
+    describe 'Remove-PoshBotStatefulData' {
+        # Define internal variables
+        $pbc = [pscustomobject]@{
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
+        }
+        $poshbotcontext = [pscustomobject]@{
+            Plugin = 'TestPlugin'
+        }
+        $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
+        $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
+        [pscustomobject]@{
+            a = 'g'
+            b = $true
+        } | Export-Clixml -Path $globalfile
+        [pscustomobject]@{
+            a = 'm'
+            b = $true
+        } | Export-Clixml -Path $modulefile
+
+        it 'Removes data as expected' {
+            Remove-PoshBotStatefulData -Scope Module -Name a
+            Remove-PoshBotStatefulData -Scope Global -Name b
+
+            $m = Import-Clixml -Path $modulefile
+            $m.b | Should Be $True
+            @($m.psobject.properties).count | Should Be 1
+            
+            $g = Import-Clixml -Path $globalfile
+            $g.a | Should Be 'g'
+            @($g.psobject.properties).count | Should Be 1
+
+            Remove-Item $globalfile -Force
+            Remove-Item $modulefile -Force
+        }
+        Remove-Item $globalfile -Force -ErrorAction SilentlyContinue
+        Remove-Item $modulefile -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/Tests/Unit/Public/Set-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Set-PoshBotStatefulData.tests.ps1
@@ -1,0 +1,63 @@
+
+InModuleScope PoshBot {
+    describe 'Set-PoshBotStatefulData' {
+        # Define internal variables
+        $pbc = [pscustomobject]@{
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
+        }
+        $poshbotcontext = [pscustomobject]@{
+            Plugin = 'TestPlugin'
+        }
+        $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
+        $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
+
+        it 'Adds data as expected' {
+            Set-PoshBotStatefulData -Scope Module -Name a -Value 'm'
+            Set-PoshBotStatefulData -Scope Global -Name a -Value 'g'
+            $m = Import-Clixml -Path $modulefile
+            $m.a | Should Be 'm'
+            @($m.psobject.properties).count | Should Be 1
+            
+            $g = Import-Clixml -Path $globalfile
+            $g.a | Should Be 'g'
+            @($g.psobject.properties).count | Should Be 1
+
+            Remove-Item $globalfile -Force
+            Remove-Item $modulefile -Force
+        }
+
+        it 'Appends to existing files' {
+            Set-PoshBotStatefulData -Scope Module -Name a -Value 'm'
+            Set-PoshBotStatefulData -Scope Global -Name a -Value 'g'
+            Set-PoshBotStatefulData -Scope Module -Name b -Value $true
+            Set-PoshBotStatefulData -Scope Global -Name b -Value $true
+            
+            $m = Import-Clixml -Path $modulefile
+            $m.a | Should Be 'm'
+            $m.b | Should Be $True
+            @($m.psobject.properties).count | Should Be 2
+            
+            $g = Import-Clixml -Path $globalfile
+            $g.a | Should Be 'g'
+            $g.b | Should Be $True
+            @($g.psobject.properties).count | Should Be 2
+
+            Remove-Item $globalfile -Force
+            Remove-Item $modulefile -Force
+        }
+
+        it 'Intentionally clobbers existing data' {
+            Set-PoshBotStatefulData -Scope Global -Name a -Value 'g'
+            Set-PoshBotStatefulData -Scope Global -Name a -Value $true
+            
+            $g = Import-Clixml -Path $globalfile
+            $g.a | Should Be $True
+            @($g.psobject.properties).count | Should Be 1
+
+            Remove-Item $globalfile -Force
+        }
+
+        Remove-Item $globalfile -Force -ErrorAction SilentlyContinue
+        Remove-Item $modulefile -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/Tests/Unit/Public/Set-PoshBotStatefulData.tests.ps1
+++ b/Tests/Unit/Public/Set-PoshBotStatefulData.tests.ps1
@@ -2,14 +2,12 @@
 InModuleScope PoshBot {
     describe 'Set-PoshBotStatefulData' {
         # Define internal variables
-        $pbc = [pscustomobject]@{
-            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
-        }
         $poshbotcontext = [pscustomobject]@{
             Plugin = 'TestPlugin'
+            ConfigurationDirectory = (Join-Path $env:BHProjectPath Tests)
         }
-        $globalfile = Join-Path $pbc.ConfigurationDirectory "PoshbotGlobal.state"
-        $modulefile = Join-Path $pbc.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
+        $globalfile = Join-Path $poshbotcontext.ConfigurationDirectory "PoshbotGlobal.state"
+        $modulefile = Join-Path $poshbotcontext.ConfigurationDirectory "$($poshbotcontext.Plugin).state"
 
         it 'Adds data as expected' {
             Set-PoshBotStatefulData -Scope Module -Name a -Value 'm'


### PR DESCRIPTION
Add initial get-it-working stateful data functions

## Description

This adds `Get-PoshBotStatefulData`, `Set-PoshBotStatefulData`, and `Remove-PoshBotStatefulData` functions.

## Related Issue

#30 

## Motivation and Context

These functions enable plugin authors to maintain state between commands and plugins.

## How Has This Been Tested?

With the included `test` task

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project. (Maybe.  I tried.)
- [x] My change requires a change to the documentation. (TODO)
- [x] I have updated the documentation accordingly. (Comment based help.  Later: external docs)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
