### PR TITLE
Adjust help filter to match exact first

### DIFF
--- a/PoshBot/Plugins/Builtin/Public/Get-CommandHelp.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Get-CommandHelp.ps1
@@ -67,15 +67,23 @@ function Get-CommandHelp {
     $result = @()
     if ($PSBoundParameters.ContainsKey('Filter')) {
         $respParams.Title = "Commands matching [$Filter]"
-        $result = @($allCommands | Where-Object {
-            ($_.FullCommandName -like "*$Filter*") -or
-            ($_.Command -like "*$Filter*") -or
-            ($_.Plugin -like "*$Filter*") -or
-            ($_.Version -like "*$Filter*") -or
-            ($_.Description -like "*$Filter*") -or
-            ($_.Usage -like "*$Filter*") -or
-            ($_.Aliases -like "*$Filter*")
-        })
+        $exact = @($allCommands.where({
+            $_.FullCommandName -like $Filter -or
+            $_.Command -like $Filter -or
+            $_.Aliases -like $Filter}))
+        if($exact.count -eq 1) {
+            $result = $Exact
+        } else {
+            $result = @($allCommands | Where-Object {
+                ($_.FullCommandName -like "*$Filter*") -or
+                ($_.Command -like "*$Filter*") -or
+                ($_.Plugin -like "*$Filter*") -or
+                ($_.Version -like "*$Filter*") -or
+                ($_.Description -like "*$Filter*") -or
+                ($_.Usage -like "*$Filter*") -or
+                ($_.Aliases -like "*$Filter*")
+            })
+        }
     } else {
         $respParams.Title = 'All commands'
         $result = $allCommands


### PR DESCRIPTION
When calling `Get-CommandHelp`, we check full command name, command, and aliases.  A user would likely expect to run help against a command that runs, regardless of whether it is an alias or command name.

Intentionally used like.  Still lets us match on unique command if user throws in a wildcard that happens to only bring back one command

## Description

Details in #43 

## Related Issue

#43 

## Motivation and Context

To improve poshbot-based help

## How Has This Been Tested?

Manually tested.

`help group`

Matches `group` command only, with details - yay! (fixes #43)

`help group*`

Matches and command with group anywhere in it (previous behavior).  Poshbot sees that more than one command comes back from `group*` command, appends `*` to start and end of filter.  I'm iffy on this behavior now that I spell it out.  Should we use `-eq` instead of `-like`?

`help grou`

Matches any command with grou anywhere in it (previous behavior).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Depends what you classify previous behavior as : )

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Cheers!