### PR TITLE
Constrain bot functionality by channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.0] Unreleased
+### Added
+  - PoshBot can now be constrained to certain channels via a whitelist in the bot configuration. Commands initiated from other channels will be ignored.
+  - DMs to the bot can be disallowed via configuration.
+
+### Fixed
+  - Configuration settings for commands requiring approval were not be saved to disk correctly.
+
 ## [0.8.0] 2017-10-01
 ### Added
   - Commands can now be marked as needing approval by someone in a designated group.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.9.0] Unreleased
 ### Added
   - PoshBot can now be constrained to certain channels via a whitelist in the bot configuration. Commands initiated from other channels will be ignored.
-  - DMs to the bot can be disallowed via configuration.
+  - Direct messages (DMs) to the bot can be disallowed via configuration.
 
 ### Fixed
   - Configuration settings for commands requiring approval were not be saved to disk correctly.

--- a/PoshBot/Classes/ApprovalCommandConfiguration.ps1
+++ b/PoshBot/Classes/ApprovalCommandConfiguration.ps1
@@ -1,12 +1,20 @@
 
 class ApprovalCommandConfiguration {
-    [string]$PluginCommandExpression
+    [string]$Expression
     [System.Collections.ArrayList]$ApprovalGroups
     [bool]$PeerApproval
 
     ApprovalCommandConfiguration() {
-        $this.PluginCommandExpression = [string]::Empty
+        $this.Expression = [string]::Empty
         $this.ApprovalGroups = New-Object -TypeName System.Collections.ArrayList
         $this.PeerApproval = $true
+    }
+
+    [hashtable]ToHash() {
+        return @{
+            Expression = $this.Expression
+            Groups = $this.ApprovalGroups
+            PeerApproval = $this.PeerApproval
+        }
     }
 }

--- a/PoshBot/Classes/ApprovalConfiguration.ps1
+++ b/PoshBot/Classes/ApprovalConfiguration.ps1
@@ -7,4 +7,17 @@ class ApprovalConfiguration {
         $this.ExpireMinutes = 30
         $this.Commands = New-Object -TypeName System.Collections.ArrayList
     }
+
+    [hashtable]ToHash() {
+        $hash = @{
+            ExpireMinutes = $this.ExpireMinutes
+        }
+        $cmds = New-Object -TypeName System.Collections.ArrayList
+        $this.Commands | Foreach-Object {
+            $cmds.Add($_.ToHash()) > $null
+        }
+        $hash.Commands = $cmds
+
+        return $hash
+    }
 }

--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -586,12 +586,12 @@ class Bot : BaseLogger {
         # Match command against included/excluded commands for the channel
         # If there is a channel match, assume command is NOT approved unless
         # it matches the included commands list and DOESN'T match the excluded list
-        foreach ($channelConfig in $this.Configuration.ApprovedCommandsInChannel) {
-            if ($channel -like $channelConfig.Channel) {
-                foreach ($includedCommand in $channelConfig.IncludeCommands) {
+        foreach ($ChannelRule in $this.Configuration.ChannelRules) {
+            if ($channel -like $ChannelRule.Channel) {
+                foreach ($includedCommand in $ChannelRule.IncludeCommands) {
                     if ($fullyQualifiedCommand -like $includedCommand) {
                         $this.LogDebug("Matched [$fullyQualifiedCommand] to included command [$includedCommand]")
-                        foreach ($excludedCommand in $channelConfig.ExcludeCommands) {
+                        foreach ($excludedCommand in $ChannelRule.ExcludeCommands) {
                             if ($fullyQualifiedCommand -like $excludedCommand) {
                                 $this.LogDebug("Matched [$fullyQualifiedCommand] to excluded command [$excludedCommand]")
                                 return $false

--- a/PoshBot/Classes/BotConfiguration.ps1
+++ b/PoshBot/Classes/BotConfiguration.ps1
@@ -43,5 +43,6 @@ class BotConfiguration {
 
     [bool]$AddCommandReactions = $true
 
+    [bool]$DisallowDMs = $false
     [ApprovalConfiguration]$ApprovalConfiguration = [ApprovalConfiguration]::new()
 }

--- a/PoshBot/Classes/BotConfiguration.ps1
+++ b/PoshBot/Classes/BotConfiguration.ps1
@@ -45,7 +45,7 @@ class BotConfiguration {
 
     [bool]$DisallowDMs = $false
 
-    [ChannelApprovedCommand[]]$ApprovedCommandsInChannel = @([ChannelApprovedCommand]::new())
+    [ChannelRule[]]$ChannelRules = @([ChannelRule]::new())
 
     [ApprovalConfiguration]$ApprovalConfiguration = [ApprovalConfiguration]::new()
 }

--- a/PoshBot/Classes/BotConfiguration.ps1
+++ b/PoshBot/Classes/BotConfiguration.ps1
@@ -44,5 +44,8 @@ class BotConfiguration {
     [bool]$AddCommandReactions = $true
 
     [bool]$DisallowDMs = $false
+
+    [ChannelApprovedCommand[]]$ApprovedCommandsInChannel = @([ChannelApprovedCommand]::new())
+
     [ApprovalConfiguration]$ApprovalConfiguration = [ApprovalConfiguration]::new()
 }

--- a/PoshBot/Classes/ChannelApprovedCommand.ps1
+++ b/PoshBot/Classes/ChannelApprovedCommand.ps1
@@ -1,0 +1,22 @@
+
+class ChannelApprovedCommand {
+    [string]$Channel
+    [string[]]$Commands
+
+    ChannelApprovedCommand() {
+        $this.Channel = '*'
+        $this.Commands = @('*')
+    }
+
+    ChannelApprovedCommand([string]$Channel, [string[]]$Commands) {
+        $this.Channel = $Channel
+        $this.Commands = $Commands
+    }
+
+    [hashtable]ToHash() {
+        return @{
+            Channel = $this.Channel
+            Commands = $this.Commands
+        }
+    }
+}

--- a/PoshBot/Classes/ChannelApprovedCommand.ps1
+++ b/PoshBot/Classes/ChannelApprovedCommand.ps1
@@ -1,22 +1,26 @@
 
 class ChannelApprovedCommand {
     [string]$Channel
-    [string[]]$Commands
+    [string[]]$IncludeCommands
+    [string[]]$ExcludeCommands
 
     ChannelApprovedCommand() {
         $this.Channel = '*'
-        $this.Commands = @('*')
+        $this.IncludeCommands = @('*')
+        $this.ExcludeCommands = @()
     }
 
-    ChannelApprovedCommand([string]$Channel, [string[]]$Commands) {
+    ChannelApprovedCommand([string]$Channel, [string[]]$IncludeCommands, [string]$ExcludeCommands) {
         $this.Channel = $Channel
-        $this.Commands = $Commands
+        $this.IncludeCommands = $IncludeCommands
+        $this.ExcludeCommands = $ExcludeCommands
     }
 
     [hashtable]ToHash() {
         return @{
             Channel = $this.Channel
-            Commands = $this.Commands
+            IncludeCommands = $this.IncludeCommands
+            ExcludeCommands = $this.ExcludeCommands
         }
     }
 }

--- a/PoshBot/Classes/ChannelRule.ps1
+++ b/PoshBot/Classes/ChannelRule.ps1
@@ -1,16 +1,16 @@
 
-class ChannelApprovedCommand {
+class ChannelRule {
     [string]$Channel
     [string[]]$IncludeCommands
     [string[]]$ExcludeCommands
 
-    ChannelApprovedCommand() {
+    ChannelRule() {
         $this.Channel = '*'
         $this.IncludeCommands = @('*')
         $this.ExcludeCommands = @()
     }
 
-    ChannelApprovedCommand([string]$Channel, [string[]]$IncludeCommands, [string]$ExcludeCommands) {
+    ChannelRule([string]$Channel, [string[]]$IncludeCommands, [string]$ExcludeCommands) {
         $this.Channel = $Channel
         $this.IncludeCommands = $IncludeCommands
         $this.ExcludeCommands = $ExcludeCommands

--- a/PoshBot/Classes/CommandExecutor.ps1
+++ b/PoshBot/Classes/CommandExecutor.ps1
@@ -83,7 +83,7 @@ class CommandExecutor : BaseLogger {
                 $msg = "Approval is needed to run [$($cmdExecContext.ParsedCommand.CommandString)] from someone in the approval group(s) [$approverGroups]."
                 $msg += "`nTo approve, say '$($prefix)approve $($cmdExecContext.Id)'."
                 $msg += "`nTo deny, say '$($prefix)deny $($cmdExecContext.Id)'."
-                $msg += "`nTo list pending approvals, say '$($prefix)pendingapprovals'."
+                $msg += "`nTo list pending approvals, say '$($prefix)pending'."
                 $response = [Response]::new()
                 $response.MessageFrom = $cmdExecContext.Message.From
                 $response.To = $cmdExecContext.Message.To
@@ -306,7 +306,7 @@ class CommandExecutor : BaseLogger {
     [bool]ApprovalNeeded([CommandExecutionContext]$Context) {
         if ($Context.ApprovalState -ne [ApprovalState]::Approved) {
             foreach ($approvalConfig in $this._bot.Configuration.ApprovalConfiguration.Commands) {
-                if ($Context.FullyQualifiedCommandName -like $approvalConfig.PluginCommandExpression) {
+                if ($Context.FullyQualifiedCommandName -like $approvalConfig.Expression) {
 
                     $approvalGroups = $this._bot.RoleManager.GetUserGroups($Context.ParsedCommand.From)
                     $compareParams = @{
@@ -343,7 +343,7 @@ class CommandExecutor : BaseLogger {
     # Get list of approval groups for a command that needs approval
     [string[]]GetApprovalGroups([CommandExecutionContext]$Context) {
         foreach ($approvalConfig in $this._bot.Configuration.ApprovalConfiguration.Commands) {
-            if ($Context.FullyQualifiedCommandName -like $approvalConfig.PluginCommandExpression) {
+            if ($Context.FullyQualifiedCommandName -like $approvalConfig.Expression) {
                 return $approvalConfig.ApprovalGroups
             }
         }

--- a/PoshBot/Classes/Message.ps1
+++ b/PoshBot/Classes/Message.ps1
@@ -10,6 +10,7 @@ class Message {
     [string]$From               # ID of user who sent the message
     [string]$FromName           # Name of user who sent the message
     [datetime]$Time             # The date/time (UTC) the message was received
+    [bool]$IsDM                 # Denotes if message is a direct message
     [hashtable]$Options         # Any other bits of information about a message. This will be backend specific
     [pscustomobject]$RawMessage # The raw message as received by the backend. This can be usefull for the backend
 

--- a/PoshBot/Implementations/Slack/SlackBackend.ps1
+++ b/PoshBot/Implementations/Slack/SlackBackend.ps1
@@ -270,6 +270,11 @@ class SlackBackend : Backend {
                             $msg.ToName = $this.ChannelIdToName($msg.To)
                         }
 
+                        # Mark as DM
+                        if ($msg.To -match '^D') {
+                            $msg.IsDM = $true
+                        }
+
                         if ($slackMessage.ts) {
                             $unixEpoch = [datetime]'1970-01-01'
                             $msg.Time = $unixEpoch.AddSeconds($slackMessage.ts)

--- a/PoshBot/PoshBot.psd1
+++ b/PoshBot/PoshBot.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PoshBot.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.8.0'
+ModuleVersion = '0.9.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/PoshBot/Public/Get-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Get-PoshBotConfiguration.ps1
@@ -87,10 +87,10 @@ function Get-PoshBotConfiguration {
                     foreach ($key in $hash.Keys) {
                         if ($config | Get-Member -MemberType Property -Name $key) {
                             switch ($key) {
-                                'ApprovedCommandsInChannel' {
-                                    $config.ApprovedCommandsInChannel = @()
+                                'ChannelRules' {
+                                    $config.ChannelRules = @()
                                     foreach ($item in $hash[$key]) {
-                                        $config.ApprovedCommandsInChannel += [ChannelApprovedCommand]::new($item.Channel, $item.IncludeCommands, $item.ExcludeCommands)
+                                        $config.ChannelRules += [ChannelRule]::new($item.Channel, $item.IncludeCommands, $item.ExcludeCommands)
                                     }
                                     break
                                 }

--- a/PoshBot/Public/Get-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Get-PoshBotConfiguration.ps1
@@ -86,24 +86,35 @@ function Get-PoshBotConfiguration {
                     $config = [BotConfiguration]::new()
                     foreach ($key in $hash.Keys) {
                         if ($config | Get-Member -MemberType Property -Name $key) {
-
-                            if ($key -eq 'ApprovalConfiguration') {
-                                # Validate ExpireMinutes
-                                if ($hash[$key].ExpireMinutes -is [int]) {
-                                    $config.ApprovalConfiguration.ExpireMinutes = $hash[$key].ExpireMinutes
-                                }
-                                # Validate ApprovalCommandConfiguration
-                                if ($hash[$key].Commands.Count -ge 1) {
-                                    foreach ($approvalConfig in $hash[$key].Commands) {
-                                        $acc = [ApprovalCommandConfiguration]::new()
-                                        $acc.Expression = $approvalConfig.Expression
-                                        $acc.ApprovalGroups = $approvalConfig.Groups
-                                        $acc.PeerApproval = $approvalConfig.PeerApproval
-                                        $config.ApprovalConfiguration.Commands.Add($acc) > $null
+                            switch ($key) {
+                                'ApprovedCommandsInChannel' {
+                                    $config.ApprovedCommandsInChannel = @()
+                                    foreach ($item in $hash[$key]) {
+                                        $config.ApprovedCommandsInChannel += [ChannelApprovedCommand]::new($item.Channel, $item.Commands)
                                     }
+                                    break
                                 }
-                            } else {
-                                $config.$Key = $hash[$key]
+                                'ApprovalConfiguration' {
+                                    # Validate ExpireMinutes
+                                    if ($hash[$key].ExpireMinutes -is [int]) {
+                                        $config.ApprovalConfiguration.ExpireMinutes = $hash[$key].ExpireMinutes
+                                    }
+                                    # Validate ApprovalCommandConfiguration
+                                    if ($hash[$key].Commands.Count -ge 1) {
+                                        foreach ($approvalConfig in $hash[$key].Commands) {
+                                            $acc = [ApprovalCommandConfiguration]::new()
+                                            $acc.Expression = $approvalConfig.Expression
+                                            $acc.ApprovalGroups = $approvalConfig.Groups
+                                            $acc.PeerApproval = $approvalConfig.PeerApproval
+                                            $config.ApprovalConfiguration.Commands.Add($acc) > $null
+                                        }
+                                    }
+                                    break
+                                }
+                                Default {
+                                    $config.$Key = $hash[$key]
+                                    break
+                                }
                             }
                         }
                     }

--- a/PoshBot/Public/Get-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Get-PoshBotConfiguration.ps1
@@ -90,7 +90,7 @@ function Get-PoshBotConfiguration {
                                 'ApprovedCommandsInChannel' {
                                     $config.ApprovedCommandsInChannel = @()
                                     foreach ($item in $hash[$key]) {
-                                        $config.ApprovedCommandsInChannel += [ChannelApprovedCommand]::new($item.Channel, $item.Commands)
+                                        $config.ApprovedCommandsInChannel += [ChannelApprovedCommand]::new($item.Channel, $item.IncludeCommands, $item.ExcludeCommands)
                                     }
                                     break
                                 }

--- a/PoshBot/Public/Get-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Get-PoshBotConfiguration.ps1
@@ -96,7 +96,7 @@ function Get-PoshBotConfiguration {
                                 if ($hash[$key].Commands.Count -ge 1) {
                                     foreach ($approvalConfig in $hash[$key].Commands) {
                                         $acc = [ApprovalCommandConfiguration]::new()
-                                        $acc.PluginCommandExpression = $approvalConfig.Expression
+                                        $acc.Expression = $approvalConfig.Expression
                                         $acc.ApprovalGroups = $approvalConfig.Groups
                                         $acc.PeerApproval = $approvalConfig.PeerApproval
                                         $config.ApprovalConfiguration.Commands.Add($acc) > $null

--- a/PoshBot/Public/New-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/New-PoshBotConfiguration.ps1
@@ -250,7 +250,7 @@ function New-PoshBotConfiguration {
     $config.DisallowDMs = ($DisallowDMs -eq $true)
     if ($ApprovedCommandsInChannel.Count -ge 1) {
         foreach ($item in $ApprovedCommandsInChannel) {
-            $config.ApprovedCommandsInChannel += [ChannelApprovedCommand]::new($item.Channel, $item.Commands)
+            $config.ApprovedCommandsInChannel += [ChannelApprovedCommand]::new($item.Channel, $item.IncludeCommands, $item.ExcludeCommands)
         }
     }
     $config.ApprovedCommandsInChannel = $ApprovedCommandsInChannel

--- a/PoshBot/Public/New-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/New-PoshBotConfiguration.ps1
@@ -248,7 +248,7 @@ function New-PoshBotConfiguration {
         [int]$ApprovalExpireMinutes = 30,
         [switch]$DisallowDMs,
         [hashtable[]]$ApprovalCommandConfigurations = @(),
-        [hashtable[]]$ChannelRules = @(@{Channel = '*'; Commands = @('*')})
+        [hashtable[]]$ChannelRules = @(@{Channel = '*'; IncludeCommands = @('*'); ExcludeCommands = @()})
     )
 
     Write-Verbose -Message 'Creating new PoshBot configuration'

--- a/PoshBot/Public/New-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/New-PoshBotConfiguration.ps1
@@ -236,7 +236,7 @@ function New-PoshBotConfiguration {
     if ($ApprovalCommandConfigurations.Count -ge 1) {
         foreach ($item in $ApprovalCommandConfigurations) {
             $acc = [ApprovalCommandConfiguration]::new()
-            $acc.PluginCommandExpression = $item.Expression
+            $acc.Expression = $item.Expression
             $acc.ApprovalGroups = $item.Groups
             $acc.PeerApproval = $item.PeerApproval
             $config.ApprovalConfiguration.Commands.Add($acc) > $null

--- a/PoshBot/Public/New-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/New-PoshBotConfiguration.ps1
@@ -99,6 +99,8 @@ function New-PoshBotConfiguration {
         Add reactions to a chat message indicating the command is being executed, has succeeded, or failed.
     .PARAMETER ApprovalExpireMinutes
         The amount of time (minutes) that a command the requires approval will be pending until it expires.
+    .PARAMETER DisallowDMs
+        Disallow DMs (direct messages) with the bot. If a user tries to DM the bot it will be ignored.
     .PARAMETER ApprovalCommandConfigurations
         Array of hashtables containing command approval configurations.
 
@@ -207,6 +209,7 @@ function New-PoshBotConfiguration {
         [int]$ApprovalExpireMinutes = 30,
         [hashtable[]]$ApprovalCommandConfigurations = @()
 
+        [switch]$DisallowDMs,
     )
 
     Write-Verbose -Message 'Creating new PoshBot configuration'
@@ -233,6 +236,7 @@ function New-PoshBotConfiguration {
     $config.SendCommandResponseToPrivate = $SendCommandResponseToPrivate
     $config.AddCommandReactions = $AddCommandReactions
     $config.ApprovalConfiguration.ExpireMinutes = $ApprovalExpireMinutes
+    $config.DisallowDMs = ($DisallowDMs -eq $true)
     if ($ApprovalCommandConfigurations.Count -ge 1) {
         foreach ($item in $ApprovalCommandConfigurations) {
             $acc = [ApprovalCommandConfiguration]::new()

--- a/PoshBot/Public/Save-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Save-PoshBotConfiguration.ps1
@@ -53,12 +53,21 @@ function Save-PoshBotConfiguration {
             $hash = @{}
             $InputObject | Get-Member -MemberType Property | ForEach-Object {
 
-                # Serialize the ApprovalConfiguration property differently as ConvertTo-Metadata
-                # won't know how to do it since it's a custom PoshBot class
-                if ($_.Name -eq 'ApprovalConfiguration') {
-                    $hash.Add($_.Name, $InputObject.($_.Name).ToHash())
-                } else {
-                    $hash.Add($_.Name, $InputObject.($_.Name))
+                switch ($_.Name) {
+                    # Serialize ApprovedCommandsInChannel and ApprovalConfiguration property differently as
+                    # ConvertTo-Metadata won't know how to do it since it's a custom PoshBot class
+                    'ApprovedCommandsInChannel' {
+                        $hash.Add($_.Name, $InputObject.($_.Name).ToHash())
+                        break
+                    }
+                    'ApprovalConfiguration' {
+                        $hash.Add($_.Name, $InputObject.($_.Name).ToHash())
+                        break
+                    }
+                    Default {
+                        $hash.Add($_.Name, $InputObject.($_.Name))
+                        break
+                    }
                 }
             }
 

--- a/PoshBot/Public/Save-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Save-PoshBotConfiguration.ps1
@@ -56,7 +56,7 @@ function Save-PoshBotConfiguration {
                 switch ($_.Name) {
                     # Serialize ApprovedCommandsInChannel and ApprovalConfiguration property differently as
                     # ConvertTo-Metadata won't know how to do it since it's a custom PoshBot class
-                    'ApprovedCommandsInChannel' {
+                    'ChannelRules' {
                         $hash.Add($_.Name, $InputObject.($_.Name).ToHash())
                         break
                     }

--- a/PoshBot/Public/Save-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/Save-PoshBotConfiguration.ps1
@@ -52,7 +52,14 @@ function Save-PoshBotConfiguration {
         if ($PSCmdlet.ShouldProcess($Path, 'Save PoshBot configuration')) {
             $hash = @{}
             $InputObject | Get-Member -MemberType Property | ForEach-Object {
-                $hash.Add($_.Name, $InputObject.($_.Name))
+
+                # Serialize the ApprovalConfiguration property differently as ConvertTo-Metadata
+                # won't know how to do it since it's a custom PoshBot class
+                if ($_.Name -eq 'ApprovalConfiguration') {
+                    $hash.Add($_.Name, $InputObject.($_.Name).ToHash())
+                } else {
+                    $hash.Add($_.Name, $InputObject.($_.Name))
+                }
             }
 
             $meta = $hash | ConvertTo-Metadata -WarningAction SilentlyContinue

--- a/docs/guides/channel-rules.md
+++ b/docs/guides/channel-rules.md
@@ -71,8 +71,11 @@ Channel rules allow the bot administrator to control what channels PoshBot is al
     ChannelRules = @(
         @{
             Channel = '*project_x*'
-            IncludeCommands = @('ProjectX:*')
-            ExcludeCommands = @('builtin:*')
+            IncludeCommands = @(
+                'ProjectX:*'
+                'builtin:*'
+            )
+            ExcludeCommands = @()
         }
     )
 }

--- a/docs/guides/channel-rules.md
+++ b/docs/guides/channel-rules.md
@@ -1,0 +1,96 @@
+
+# Channel Rules
+
+Channel rules allow the bot administrator to control what channels PoshBot is allowed to interact in, and optionally, what commands are allowed in those channels. Channel rules are evaluated in order, so it is best to specify them from most specific to least specific. Once a command is matched to a channel rule, evaluation is stopped.
+
+> When PoshBot receives a command to run, it resolves it to a fully qualified command name `<pluginname>.<commandname>.<version>`. This fully qualified name is what is evaluated against the channel rules. Even though a user may have entered an [alias](../tutorials/plugin-development/advanced/poshbot.botcommand-attribute.md#aliases) for a command, the real command name is checked. Because of this, when using channel rules, the **actual** command name must be used and not any aliases.
+
+> Note that by default, channel rules allow all commands to be executed in any channel PoshBot is participating in. If you do not explicitly define a value for `ChannelRules`, the value `@(@{Channel = '*'; IncludeCommands = @('*'); ExcludeCommands = @()})` is used. **Once you define channel rules, those rules take precedence and PoshBot will only honor commands that match the rules.**
+
+## Potential Scenarios
+
+* PoshBot should be confined to only certain channels on the chat network.
+* Some plugins or commands are particularly sensitive and there is a need to tightly control what channels those plugins/commands are executed in.
+* There is a need to whitelist or blacklist certain plugins/commands from one or more channels.
+
+## Examples
+
+### Confine PoshBot to just the `bots` channel
+
+#### mybot.psd1
+
+```powershell
+@{
+    ChannelRules = @(
+        @{
+            Channel = 'bots'
+            IncludeCommands = @('*')
+            ExcludeCommands = @()
+        }
+    )
+}
+```
+
+### Only allow builtin commands in the `botadmin` channel
+
+```powershell
+@{
+    ChannelRules = @(
+        @{
+            Channel = 'botadmin'
+            IncludeCommands = @('builtin:*')
+            ExcludeCommands = @()
+        }
+    )
+}
+```
+
+### Exclude the `PoshBot.Giphy` plugin from the `general` and **only** allow that plugin in the `random` channel
+
+```powershell
+@{
+    ChannelRules = @(
+        @{
+            Channel = 'general'
+            IncludeCommands = @('*')
+            ExcludeCommands = @('poshbot.giphy:*')
+        }
+        @{
+            Channel = 'random'
+            IncludeCommands = @('poshbot.giphy:*')
+            ExcludeCommands = @()
+        }
+    )
+}
+```
+
+### Only allow the `ProjectX` plugin in the multiple `Project X` channels along with the `Get-CommandHelp` command.
+
+```powershell
+@{
+    ChannelRules = @(
+        @{
+            Channel = '*project_x*'
+            IncludeCommands = @('ProjectX:*')
+            ExcludeCommands = @('builtin:*')
+        }
+    )
+}
+```
+
+### Only allow version `1.2.3` of the `foo` plugin in the `general` channel. All other plugins are allowed
+
+```powershell
+@{
+    ChannelRules = @(
+        @{
+            Channel = 'general'
+            IncludeCommands = @(
+                'foo:*:1.2.3'
+                '*'
+            )
+            ExcludeCommands = @()
+        }
+    )
+}
+```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -43,7 +43,7 @@ If you look at `.\PoshBotConfig.psd1` it should resemble the following:
     Name = 'SlackBackend'
   }
   ApprovalConfiguration = @{}
-  ApprovedCommandsInChannel = @(
+  ChannelRules = @(
     @{
       Channel = '*'
       IncludeCommands = @('*')
@@ -91,7 +91,7 @@ MuteUnknownCommand                | bool        | Control whether unknown comman
 ApprovalExpireMinutes             | int         | The amount of time (minutes) that a command the requires approval will be pending until it expires
 ApprovalCommandConfigurations     | hashtable[] | Array of hashtables containing command approval configurations
 DisallowDMs                       | bool        | Disallow commands in DM channels with PoshBot
-ApprovedCommandsInChannel         | hashtable[] | Array of whitelisted channels the bot can participate in
+ChannelRules                      | hashtable[] | Array of channels rules that control what plugin commands are allowed in a channel
 
 ## Storage
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -46,7 +46,8 @@ If you look at `.\PoshBotConfig.psd1` it should resemble the following:
   ApprovedCommandsInChannel = @(
     @{
       Channel = '*'
-      Commands = @('*')
+      IncludeCommands = @('*')
+      ExcludeCommands = @()
     }
   )
   DisallowDMs = $false

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -39,9 +39,17 @@ If you look at `.\PoshBotConfig.psd1` it should resemble the following:
   AlternateCommandPrefixes = @('poshbot')
   CommandPrefix = '!'
   BackendConfiguration = @{
-    Token = 'SLACK-API-TOKEN'
+    Token = '<SLACK-API-TOKEN>'
     Name = 'SlackBackend'
   }
+  ApprovalConfiguration = @{}
+  ApprovedCommandsInChannel = @(
+    @{
+      Channel = '*'
+      Commands = @('*')
+    }
+  )
+  DisallowDMs = $false
 }
 ```
 
@@ -56,29 +64,33 @@ $bot.Start()
 
 Here is a rundown of the various configuration properties and what they do:
 
-| Property                        | Type      | Description |
-|:--------------------------------|:----------|:------------|
-Name                              | string    | A name of the bot
-ConfigurationDirectory            | string    | The directory to store bot configuration in
-LogDirectory                      | string    | The directory to store bot logs in
-PluginDirectory                   | string    | The directory to first look for plugins (modules) in
-PluginRepository                  | string[]  | The PowerShell repository(s) to look for plugins (modules) in
-ModuleManifestsToLoad             | string[]  | Path(s) to module manifests to load at bot startup
-AddCommandReactions               | bool      | Add reactions to a chat message indicating the command is being executed, has succeeded, or failed
-LogLevel                          | string    | The verbosity of logs
-MaxLogSizeMB                      | int       | The maximum log file size in megabytes
-MaxLogsToKeep                     | int       | The maximum number of logs to keep before rotating
-LogCommandHistory                 | bool      | Log command history to a separate file for convenience
-CommandHistoryMaxLogSizeMB        | int       | The maximum log file size for the command history
-CommandHistoryMaxLogsToKeep       | int       | The maximum number of logs to keep for command history before rotating
-BackendConfiguration              | hashtable | Hashtable containing configuration settings needed by backend provider
-PluginConfiguration               | hashtable | Hashtable of parameter values to pass to bot commands when appropriate
-BotAdmins                         | string[]  | List of chat handles who will granted bot administrator privledges
-CommandPrefix                     | char      | Primary prefix to use to determine if messages are bot commands
-AlternateCommandPrefixes          | string[]  | Alternate prefix(es) to use to determine if messages are bot commands
-AlternateCommandPrefixSeperators  | char[]    | Alternate prefix seperator(s) to use to determine if messages are bot commands
-SendCommandResponseToPrivate      | string[]  | Array of fully qualified bot commands to redirect responses to DM channels
-MuteUnknownCommand                | bool      | Control whether unknown commands produce warning message back to chat network
+| Property                        | Type        | Description |
+|:--------------------------------|:------------|:------------|
+Name                              | string      | A name of the bot
+ConfigurationDirectory            | string      | The directory to store bot configuration in
+LogDirectory                      | string      | The directory to store bot logs in
+PluginDirectory                   | string      | The directory to first look for plugins (modules) in
+PluginRepository                  | string[]    | The PowerShell repository(s) to look for plugins (modules) in
+ModuleManifestsToLoad             | string[]    | Path(s) to module manifests to load at bot startup
+AddCommandReactions               | bool        | Add reactions to a chat message indicating the command is being executed, has succeeded, or failed
+LogLevel                          | string      | The verbosity of logs
+MaxLogSizeMB                      | int         | The maximum log file size in megabytes
+MaxLogsToKeep                     | int         | The maximum number of logs to keep before rotating
+LogCommandHistory                 | bool        | Log command history to a separate file for convenience
+CommandHistoryMaxLogSizeMB        | int         | The maximum log file size for the command history
+CommandHistoryMaxLogsToKeep       | int         | The maximum number of logs to keep for command history before rotating
+BackendConfiguration              | hashtable   | Hashtable containing configuration settings needed by backend provider
+PluginConfiguration               | hashtable   | Hashtable of parameter values to pass to bot commands when appropriate
+BotAdmins                         | string[]    | List of chat handles who will granted bot administrator privledges
+CommandPrefix                     | char        | Primary prefix to use to determine if messages are bot commands
+AlternateCommandPrefixes          | string[]    | Alternate prefix(es) to use to determine if messages are bot commands
+AlternateCommandPrefixSeperators  | char[]      | Alternate prefix seperator(s) to use to determine if messages are bot commands
+SendCommandResponseToPrivate      | string[]    | Array of fully qualified bot commands to redirect responses to DM channels
+MuteUnknownCommand                | bool        | Control whether unknown commands produce warning message back to chat network
+ApprovalExpireMinutes             | int         | The amount of time (minutes) that a command the requires approval will be pending until it expires
+ApprovalCommandConfigurations     | hashtable[] | Array of hashtables containing command approval configurations
+DisallowDMs                       | bool        | Disallow commands in DM channels with PoshBot
+ApprovedCommandsInChannel         | hashtable[] | Array of whitelisted channels the bot can participate in
 
 ## Storage
 

--- a/docs/reference/commands/Add-CommandPermission.md
+++ b/docs/reference/commands/Add-CommandPermission.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Approve-PendingCommand.md
+++ b/docs/reference/commands/Approve-PendingCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Deny-PendingCommand.md
+++ b/docs/reference/commands/Deny-PendingCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Disable-ScheduledCommand.md
+++ b/docs/reference/commands/Disable-ScheduledCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Enable-ScheduledCommand.md
+++ b/docs/reference/commands/Enable-ScheduledCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Find-Plugin.md
+++ b/docs/reference/commands/Find-Plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Get-CommandHelp.md
+++ b/docs/reference/commands/Get-CommandHelp.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Get-CommandHistory.md
+++ b/docs/reference/commands/Get-CommandHistory.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Get-CommandStatus.md
+++ b/docs/reference/commands/Get-CommandStatus.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Get-PendingCommand.md
+++ b/docs/reference/commands/Get-PendingCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Get-PoshBotStatus.md
+++ b/docs/reference/commands/Get-PoshBotStatus.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Get-ScheduledCommand.md
+++ b/docs/reference/commands/Get-ScheduledCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/New-Permission.md
+++ b/docs/reference/commands/New-Permission.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/New-ScheduledCommand.md
+++ b/docs/reference/commands/New-ScheduledCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Remove-Group.md
+++ b/docs/reference/commands/Remove-Group.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Remove-Plugin.md
+++ b/docs/reference/commands/Remove-Plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Remove-Role.md
+++ b/docs/reference/commands/Remove-Role.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Remove-ScheduledCommand.md
+++ b/docs/reference/commands/Remove-ScheduledCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Set-ScheduledCommand.md
+++ b/docs/reference/commands/Set-ScheduledCommand.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Slap.md
+++ b/docs/reference/commands/Slap.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Update-GroupDescription.md
+++ b/docs/reference/commands/Update-GroupDescription.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Update-Plugin.md
+++ b/docs/reference/commands/Update-Plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/Update-RoleDescription.md
+++ b/docs/reference/commands/Update-RoleDescription.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/about.md
+++ b/docs/reference/commands/about.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/add-grouprole.md
+++ b/docs/reference/commands/add-grouprole.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/add-groupuser.md
+++ b/docs/reference/commands/add-groupuser.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/add-rolepermission.md
+++ b/docs/reference/commands/add-rolepermission.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/disable-plugin.md
+++ b/docs/reference/commands/disable-plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/enable-plugin.md
+++ b/docs/reference/commands/enable-plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/get-group.md
+++ b/docs/reference/commands/get-group.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/get-permission.md
+++ b/docs/reference/commands/get-permission.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/get-plugin.md
+++ b/docs/reference/commands/get-plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/get-role.md
+++ b/docs/reference/commands/get-role.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/install-plugin.md
+++ b/docs/reference/commands/install-plugin.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/new-group.md
+++ b/docs/reference/commands/new-group.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/new-role.md
+++ b/docs/reference/commands/new-role.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/remove-grouprole.md
+++ b/docs/reference/commands/remove-grouprole.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/remove-groupuser.md
+++ b/docs/reference/commands/remove-groupuser.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/commands/remove-rolepermission.md
+++ b/docs/reference/commands/remove-rolepermission.md
@@ -1,5 +1,6 @@
 ---
 external help file: Builtin-help.xml
+Module Name: Builtin
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/Get-PoshBotStatefulData.md
+++ b/docs/reference/functions/Get-PoshBotStatefulData.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/New-PoshBotFileUpload.md
+++ b/docs/reference/functions/New-PoshBotFileUpload.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/Remove-PoshBotStatefulData.md
+++ b/docs/reference/functions/Remove-PoshBotStatefulData.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/Set-PoshBotStatefulData.md
+++ b/docs/reference/functions/Set-PoshBotStatefulData.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/get-poshbot.md
+++ b/docs/reference/functions/get-poshbot.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/get-poshbotconfiguration.md
+++ b/docs/reference/functions/get-poshbotconfiguration.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/new-poshbotcardresponse.md
+++ b/docs/reference/functions/new-poshbotcardresponse.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/new-poshbotconfiguration.md
+++ b/docs/reference/functions/new-poshbotconfiguration.md
@@ -21,7 +21,7 @@ New-PoshBotConfiguration [[-Name] <String>] [[-ConfigurationDirectory] <String>]
  [[-CommandPrefix] <Char>] [[-AlternateCommandPrefixes] <String[]>]
  [[-AlternateCommandPrefixSeperators] <Char[]>] [[-SendCommandResponseToPrivate] <String[]>]
  [[-MuteUnknownCommand] <Boolean>] [[-AddCommandReactions] <Boolean>] [[-ApprovalExpireMinutes] <Int32>]
- [-DisallowDMs] [[-ApprovalCommandConfigurations] <Hashtable[]>] [[-ApprovedCommandsInChannel] <Hashtable[]>]
+ [-DisallowDMs] [[-ApprovalCommandConfigurations] <Hashtable[]>] [[-ChannelRules] <Hashtable[]>]
 ```
 
 ## DESCRIPTION
@@ -531,11 +531,10 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ApprovedCommandsInChannel
-Array of whitelisted channels the bot can participate in.
-Wildcards are allowed.
-Channel names that
-match against this list will be allowed to have Poshbot commands executed in them.
+### -ChannelRules
+Array of channels rules that control what plugin commands are allowed in a channel.
+Wildcards are supported.
+Channel names that match against this list will be allowed to have Poshbot commands executed in them.
 
 Internally this uses the \`-like\` comparison operator, not \`-match\`.
 Regexes are not allowed.
@@ -547,6 +546,34 @@ evaluate the first match found.
 Note that the bot will still receive messages from all channels it is a member of.
 These message MAY
 be logged depending on your configured logging level.
+
+Example value:
+@(
+    # Only allow builtin commands in the 'botadmin' channel
+    @{
+        Channel = 'botadmin'
+        IncludeCommands = @('builtin:*')
+        ExcludeCommands = @()
+    }
+    # Exclude builtin commands from any "projectX" channel
+    @{
+        Channel = '*projectx*'
+        IncludeCommands = @('*')
+        ExcludeCommands = @('builtin:*')
+    }
+    # It's the wild west in random, except giphy :)
+    @{
+        Channel = 'random'
+        IncludeCommands = @('*')
+        ExcludeCommands = @('*giphy*')
+    }
+    # All commands are otherwise allowed
+    @{
+        Channel = '*'
+        IncludeCommands = @('*')
+        ExcludeCommands = @()
+    }
+)
 
 ```yaml
 Type: Hashtable[]

--- a/docs/reference/functions/new-poshbotconfiguration.md
+++ b/docs/reference/functions/new-poshbotconfiguration.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---
@@ -20,7 +21,7 @@ New-PoshBotConfiguration [[-Name] <String>] [[-ConfigurationDirectory] <String>]
  [[-CommandPrefix] <Char>] [[-AlternateCommandPrefixes] <String[]>]
  [[-AlternateCommandPrefixSeperators] <Char[]>] [[-SendCommandResponseToPrivate] <String[]>]
  [[-MuteUnknownCommand] <Boolean>] [[-AddCommandReactions] <Boolean>] [[-ApprovalExpireMinutes] <Int32>]
- [[-ApprovalCommandConfigurations] <Hashtable[]>]
+ [-DisallowDMs] [[-ApprovalCommandConfigurations] <Hashtable[]>] [[-ApprovedCommandsInChannel] <Hashtable[]>]
 ```
 
 ## DESCRIPTION
@@ -486,6 +487,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -DisallowDMs
+Disallow DMs (direct messages) with the bot.
+If a user tries to DM the bot it will be ignored.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ApprovalCommandConfigurations
 Array of hashtables containing command approval configurations.
 
@@ -510,6 +527,35 @@ Aliases:
 Required: False
 Position: 23
 Default value: @()
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ApprovedCommandsInChannel
+Array of whitelisted channels the bot can participate in.
+Wildcards are allowed.
+Channel names that
+match against this list will be allowed to have Poshbot commands executed in them.
+
+Internally this uses the \`-like\` comparison operator, not \`-match\`.
+Regexes are not allowed.
+
+For best results, list channels and commands from most specific to least specific.
+PoshBot will
+evaluate the first match found.
+
+Note that the bot will still receive messages from all channels it is a member of.
+These message MAY
+be logged depending on your configured logging level.
+
+```yaml
+Type: Hashtable[]
+Parameter Sets: (All)
+Aliases: 
+
+Required: False
+Position: 24
+Default value: @(@{Channel = '*'; Commands = @('*')})
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/reference/functions/new-poshbotinstance.md
+++ b/docs/reference/functions/new-poshbotinstance.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/new-poshbotscheduledtask.md
+++ b/docs/reference/functions/new-poshbotscheduledtask.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/new-poshbotslackbackend.md
+++ b/docs/reference/functions/new-poshbotslackbackend.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/new-poshbottextresponse.md
+++ b/docs/reference/functions/new-poshbottextresponse.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/save-poshbotconfiguration.md
+++ b/docs/reference/functions/save-poshbotconfiguration.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/start-poshbot.md
+++ b/docs/reference/functions/start-poshbot.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/docs/reference/functions/stop-poshbot.md
+++ b/docs/reference/functions/stop-poshbot.md
@@ -1,5 +1,6 @@
 ---
 external help file: PoshBot-help.xml
+Module Name: poshbot
 online version: 
 schema: 2.0.0
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ pages:
     - Triggers: guides/triggers.md
     - Scheduled Commands: guides/scheduled-commands.md
     - Scheduled Task: guides/scheduled-task.md
+    - Channel Rules: guides/channel-rules.md
     - Command Approvals: guides/command-approvals.md
     - Command Authorization:
       - Overview: guides/command-authorization/overview.md

--- a/psake.ps1
+++ b/psake.ps1
@@ -175,7 +175,7 @@ task Compile -depends Clean {
         'Backend'
         'ApprovalCommandConfiguration'
         'ApprovalConfiguration'
-        'ChannelApprovedCommand'
+        'ChannelRule'
         'BotConfiguration'
         'Bot'
     ) | ForEach-Object {

--- a/psake.ps1
+++ b/psake.ps1
@@ -175,6 +175,7 @@ task Compile -depends Clean {
         'Backend'
         'ApprovalCommandConfiguration'
         'ApprovalConfiguration'
+        'ChannelApprovedCommand'
         'BotConfiguration'
         'Bot'
     ) | ForEach-Object {


### PR DESCRIPTION
## Description
This PR adds support for constraining PoshBot to certain channels and also controlling what plugin commands are allowed in said channels.

This also fixed a bug where the approval configuration settings where not being saved to the bot config file correctly.

There is a new bot configuration property called ChannelRules that is a `hashtable[]` to control what commands are included and excluded from channels(s). Wild cards are supported so multiple channels can be covered by a single "rule". The rules are evaluated in order so the most specific ones should be added first.

The fully qualified command name <plugin>:<commandname>:<version> is what is evaluated so the rule examples below are supported.

- "all commands in plugin A"
- "version 1.2.3 of plugin X"
- "only command Y of plugin Z"

#### Example bot.psd1
```powershell
@{
    ChannelRules= @(
        # Only builtin and admin plugin commands allowed in the admin channel
        @{
            Channel = 'admin'
            IncludeCommands = @(
                'builtin:*'
                'myadminplugin:*'
            )
        }
        # It's the wild west in random, except giphy :)
        @{
            Channel = 'random'
            IncludeCommands = @('*')
            ExcludeCommands = @('*giphy*')
        }
        # Exclude builtin commands from any "projectX" channel
        @{
            Channel = '*projectx*'
            IncludeCommands = @('*')
            ExcludeCommands = @('builtin:*')
        }
        # All commands are otherwise allowed
        @{
            Channel = '*'
            IncludeCommands = @('*')
            ExcludeCommands = @()
        }
    )
}
```

## Related Issue
#36 

## Motivation and Context
See #36

## How Has This Been Tested?
Manually tested new functionality 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
