### PR TITLE
Add FormatEnumerationLimitOverride to config

### DIFF
--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -131,7 +131,11 @@ class Bot : BaseLogger {
     [void]Start() {
         $this._Stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $this.LogInfo('Start your engines')
-
+        $OldFormatEnumerationLimit = $global:FormatEnumerationLimit
+        if($this.Configuration.FormatEnumerationLimitOverride -is [int]) {
+            $global:FormatEnumerationLimit = $this.Configuration.FormatEnumerationLimitOverride
+            $this.LogInfo("Setting global FormatEnumerationLimit to [$($this.Configuration.FormatEnumerationLimitOverride)]")
+        }
         try {
             $this.Connect()
 
@@ -167,6 +171,7 @@ class Bot : BaseLogger {
         } catch {
             $this.LogInfo([LogSeverity]::Error, "$($_.Exception.Message)", [ExceptionFormatter]::Summarize($_))
         } finally {
+            $global:FormatEnumerationLimit = $OldFormatEnumerationLimit
             $this.Disconnect()
         }
     }

--- a/PoshBot/Classes/BotConfiguration.ps1
+++ b/PoshBot/Classes/BotConfiguration.ps1
@@ -45,6 +45,8 @@ class BotConfiguration {
 
     [bool]$DisallowDMs = $false
 
+    [int]$FormatEnumerationLimitOverride = -1
+
     [ChannelRule[]]$ChannelRules = @([ChannelRule]::new())
 
     [ApprovalConfiguration]$ApprovalConfiguration = [ApprovalConfiguration]::new()

--- a/PoshBot/Public/New-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/New-PoshBotConfiguration.ps1
@@ -101,6 +101,12 @@ function New-PoshBotConfiguration {
         The amount of time (minutes) that a command the requires approval will be pending until it expires.
     .PARAMETER DisallowDMs
         Disallow DMs (direct messages) with the bot. If a user tries to DM the bot it will be ignored.
+    .PARAMETER FormatEnumerationLimitOverride
+        Set $FormatEnumerationLimit to this.  Defaults to unlimited (-1)
+        
+        Determines how many enumerated items are included in a display.
+        This variable does not affect the underlying objects; just the display.
+        When the value of $FormatEnumerationLimit is less than the number of enumerated items, PowerShell adds an ellipsis (...) to indicate items not shown.
     .PARAMETER ApprovalCommandConfigurations
         Array of hashtables containing command approval configurations.
 
@@ -247,6 +253,7 @@ function New-PoshBotConfiguration {
         [bool]$AddCommandReactions = $true,
         [int]$ApprovalExpireMinutes = 30,
         [switch]$DisallowDMs,
+        [int]$FormatEnumerationLimitOverride = -1,
         [hashtable[]]$ApprovalCommandConfigurations = @(),
         [hashtable[]]$ChannelRules = @(@{Channel = '*'; IncludeCommands = @('*'); ExcludeCommands = @()})
     )
@@ -276,6 +283,7 @@ function New-PoshBotConfiguration {
     $config.AddCommandReactions = $AddCommandReactions
     $config.ApprovalConfiguration.ExpireMinutes = $ApprovalExpireMinutes
     $config.DisallowDMs = ($DisallowDMs -eq $true)
+    $config.FormatEnumerationLimitOverride = $FormatEnumerationLimitOverride
     if ($ChannelRules.Count -ge 1) {
         foreach ($item in $ChannelRules) {
             $config.ChannelRules += [ChannelRule]::new($item.Channel, $item.IncludeCommands, $item.ExcludeCommands)


### PR DESCRIPTION
Hiyo!

This simply adds a FormatEnumerationLimitOverride key to the bot configuration, with a default of -1

Ping me if you want to have any input on changes that you'd prefer (in direction or implementation) - cheers!

## Description

Not sure if this is the direction you were looking for, or the right way to go about it if so.  The saving current value / reverting in a final block, and using the global scope [is based on this](https://github.com/nightroman/PowerShellTraps/tree/master/Basic/FormatEnumerationLimit)

* We set this at bot.start(), revert to previous setting in a final block
* We default to -1 given that output can't be explored out of the box - otherwise data can remain hidden and inaccessible

I added a parameter help bit to `New-PoshBotConfiguration`, but didn't update any example output from `Get-PoshBotConfiguration` (seems nice to have but superficial)

## Related Issue

#47 

## Motivation and Context

See #47

## How Has This Been Tested?

Manually tested by loading bot with no initial change to config; expected enumeration limit of -1 was correctly set
Manually tested by loading bot with config FormatEnumerationLimitOverride set to 6 (not default); expected limit of 6 was correctly set

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
