### PR TITLE
Improve command resolution in !help

### DIFF
--- a/PoshBot/Plugins/Builtin/Public/Get-CommandHelp.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Get-CommandHelp.ps1
@@ -89,13 +89,15 @@ function Get-CommandHelp {
     $result = @()
     if ($PSBoundParameters.ContainsKey('Filter')) {
         $respParams.Title = "Commands matching [$Filter]"
-        $exact = @($allCommands.where({
-            $_.FullCommandName -like $Filter -or
-            $_.Command -like $Filter -or
-            $_.Aliases -like $Filter}))
-        if($exact.count -eq 1) {
-            $result = $Exact
-        } else {
+        # Resolve similar to PS: qualified, alias, command
+        foreach($Property in 'FullCommandName', 'Command', 'Aliases') {
+            $exact = @($allCommands.where({ $_.$Property -like $Filter}))
+            if($exact.count -eq 1) {
+                $result = $Exact
+                break
+            }
+        }
+        if(-not $result) {
             $result = @($allCommands | Where-Object {
                 ($_.FullCommandName -like "*$Filter*") -or
                 ($_.Command -like "*$Filter*") -or
@@ -130,7 +132,7 @@ function Get-CommandHelp {
             }
             if ($HelpParams.Keys.Count -gt 0) {
                 $fullVersionName = "$($result.FullCommandName)`:$($result.Version)"
-                $manString = ($Bot.PluginManager.Commands[$fullVersionName] | Get-Help @HelpParams | Out-String)
+                $manString = Get-Help $Bot.PluginManager.Commands[$fullVersionName].ModuleCommand @HelpParams | Out-String
                 $result | Add-Member -MemberType NoteProperty -Name Manual -Value "`n$manString"
             }
             $respParams.Text = ($result | Format-List | Out-String -Width 150).Trim()


### PR DESCRIPTION
Noticed that some `Get-CommandHelp` calls were returning more data than expected (i.e. `Manual` field for commands with similar names shows doesn't show expected content with `-Examples`, `-Detailed`, or `-Full`).

## Description

* Look in FullCommandName, Aliases, Comman independently, vs. -or comparisons, which may return more than one result and change behavior
* Use pluginmanager.commands.ModuleCommand to fully qualify get-help call - this ensures the specific fully qualified command name is queried for help

## Related Issue
#67 ish

## Motivation and Context
I keep getting output for multiple commands when using `-Detailed`, `-Full`, and `-Examples`, for certain commands

## How Has This Been Tested?

Manually tested against a variety of commands that previously generated multiple items in the `Manual` field, now see expected content

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
