### PR TITLE
Add validation to Slack back end of FileUpload per #75

### DIFF
--- a/PoshBot/Public/New-PoshBotFileUpload.ps1
+++ b/PoshBot/Public/New-PoshBotFileUpload.ps1
@@ -17,6 +17,8 @@ function New-PoshBotFileUpload {
         The title for the uploaded file.
     .PARAMETER DM
         Tell PoshBot to redirect the file upload to a DM channel.
+    .PARAMETER KeepFile
+        If specified, keep the source file after calling Send-SlackFile. The source file is deleted without this
     .EXAMPLE
         function Do-Stuff {
             [cmdletbinding()]
@@ -52,6 +54,25 @@ function New-PoshBotFileUpload {
         }
 
         Export a CSV file and tell PoshBot to upload the file back to a DM channel with the calling user.
+
+    .EXAMPLE
+        function Do-Stuff {
+            [cmdletbinding()]
+            param()
+
+            $myObj = [pscustomobject]@{
+                value1 = 'foo'
+                value2 = 'bar'
+            }
+
+            $csv = Join-Path -Path $env:TEMP -ChildPath "$((New-Guid).ToString()).csv"
+            $myObj | Export-Csv -Path $csv -NoTypeInformation
+
+            New-PoshBotFileUpload -Path $csv -KeepFile
+        }
+
+        Export a CSV file and tell PoshBot to upload the file back to the channel that initiated this command.
+        Keep the file after uploading it.
     .INPUTS
         String
     .OUTPUTS
@@ -87,7 +108,9 @@ function New-PoshBotFileUpload {
 
         [string]$Title = [string]::Empty,
 
-        [switch]$DM
+        [switch]$DM,
+
+        [switch]$KeepFile
     )
 
     process {
@@ -104,6 +127,7 @@ function New-PoshBotFileUpload {
                 Path = $item
                 Title = $Title
                 DM = ($PSBoundParameters.ContainsKey('DM') -and $DM)
+                KeepFile = ($PSBoundParameters.ContainsKey('KeepFile') -and $KeepFile)
             }
         }
     }


### PR DESCRIPTION
* Validate file path before Send-SlackFile
* Add KeepFile parameter to avoid deleting source files

## Description

This prevents an invalid New-PoshBotFileUpload path from crashing poshbot, and adds an option to keep source files (leaving existing behavior as default)

## Related Issue
#75 

## Motivation and Context
See #75 

## How Has This Been Tested?
Manual testing:

* Valid path, KeepFile specified: File uploaded, file not deleted
* Valid path, KeepFile not specified: File uploaded, file deleted
* Invalid path: poshbot does not crash, sends error

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6377597/34075901-10dac9c2-e2a3-11e7-9571-c2c543db39da.png)

There may be another way to do this, not as familiar with the logic / code paths.  As is, it will look like a command succeeds, including a success indication, and then PoshBot will add an error to the specified channel.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
