### PR TITLE
add CustomData param to New-PoshBotCardResponse

### DIFF
--- a/PoshBot/Public/New-PoshBotCardResponse.ps1
+++ b/PoshBot/Public/New-PoshBotCardResponse.ps1
@@ -30,6 +30,9 @@ function New-PoshBotCardResponse {
         A hashtable to display as a table in the card response.
     .PARAMETER COLOR
         The hex color code to use for the card response. In Slack, this will be the color of the left border in the message attachment.
+    .PARAMETER CustomData
+        Any additional custom data you'd like to pass on. Useful for custom backends, in case you want to pass a specifically formatted response
+        in the Data stream of the responses received by the backend. Any data sent here will be skipped by the built-in backends provided with PoshBot itself.
     .EXAMPLE
         function Do-Something {
             [cmdletbinding()]
@@ -127,7 +130,9 @@ function New-PoshBotCardResponse {
                 throw [System.Management.Automation.ValidationMetadataException]$msg
             }
         })]
-        [string]$Color = '#D3D3D3'
+        [string]$Color = '#D3D3D3',
+
+        [object]$CustomData
     )
 
     $response = [ordered]@{
@@ -135,7 +140,7 @@ function New-PoshBotCardResponse {
         Type = $Type
         Text = $Text.Trim()
         Private = $PSBoundParameters.ContainsKey('Private')
-        DM = $PSBoundParameters.ContainsKey('DM')
+        DM = $PSBoundParameters['DM']
     }
     if ($PSBoundParameters.ContainsKey('Title')) {
         $response.Title = $Title
@@ -151,6 +156,9 @@ function New-PoshBotCardResponse {
     }
     if ($PSBoundParameters.ContainsKey('Fields')) {
         $response.Fields = $Fields
+    }
+    if ($PSBoundParameters.ContainsKey('CustomData')) {
+        $response.CustomData = $CustomData
     }
     if ($PSBoundParameters.ContainsKey('Color')) {
         $response.Color = $Color

--- a/Tests/Unit/Public/New-PoshBotCardResponse.tests.ps1
+++ b/Tests/Unit/Public/New-PoshBotCardResponse.tests.ps1
@@ -1,5 +1,5 @@
 
-describe 'New-PoshBotTextResponse' {
+describe 'New-PoshBotCardResponse' {
 
     BeforeAll {
         $imgUrl = 'https://github.com/poshbotio/PoshBot/raw/master/Media/poshbot_logo_300_432.png'

--- a/Tests/Unit/Public/New-PoshBotCardResponse.tests.ps1
+++ b/Tests/Unit/Public/New-PoshBotCardResponse.tests.ps1
@@ -50,6 +50,15 @@ describe 'New-PoshBotTextResponse' {
         $resp.Fields | should be $fields
     }
 
+    it 'Has a valid [CustomData] field' {
+        $customData = @{
+            prop1 = 'val1'
+            prop2 = 'val2'
+        } | ConvertTo-Json
+        $resp = New-PoshBotCardResponse -Text 'abc' -CustomData $CustomData
+        $resp.CustomData | should be $CustomData
+    }
+
     it 'Sets color field properly' {
         $normal = New-PoshBotCardResponse -Text 'abc' -Type Normal
         $warning = New-PoshBotCardResponse -Text 'abc' -Type Warning

--- a/docs/reference/functions/Get-PoshBotStatefulData.md
+++ b/docs/reference/functions/Get-PoshBotStatefulData.md
@@ -87,7 +87,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/New-PoshBotFileUpload.md
+++ b/docs/reference/functions/New-PoshBotFileUpload.md
@@ -180,7 +180,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/New-PoshBotMiddlewareHook.md
+++ b/docs/reference/functions/New-PoshBotMiddlewareHook.md
@@ -46,7 +46,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 0
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -61,14 +61,15 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: 1
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/New-PoshBotTeamsBackend.md
+++ b/docs/reference/functions/New-PoshBotTeamsBackend.md
@@ -58,7 +58,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/PoshBot.md
+++ b/docs/reference/functions/PoshBot.md
@@ -1,16 +1,16 @@
 ---
-Module Name: poshbot
+Module Name: PoshBot
 Module Guid: 7bfb126c-b432-4921-989a-9802f525693f
 Download Help Link: {{Please enter FwLink manually}}
 Help Version: {{Please enter version of help manually (X.X.X.X) format}}
 Locale: en-US
 ---
 
-# poshbot Module
+# PoshBot Module
 ## Description
 {{Manually Enter Description Here}}
 
-## poshbot Cmdlets
+## PoshBot Cmdlets
 ### [Get-PoshBot](Get-PoshBot.md)
 {{Manually Enter Get-PoshBot Description Here}}
 

--- a/docs/reference/functions/Remove-PoshBotStatefulData.md
+++ b/docs/reference/functions/Remove-PoshBotStatefulData.md
@@ -118,7 +118,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/Set-PoshBotStatefulData.md
+++ b/docs/reference/functions/Set-PoshBotStatefulData.md
@@ -137,7 +137,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/get-poshbot.md
+++ b/docs/reference/functions/get-poshbot.md
@@ -65,7 +65,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/get-poshbotconfiguration.md
+++ b/docs/reference/functions/get-poshbotconfiguration.md
@@ -97,7 +97,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/new-poshbotcardresponse.md
+++ b/docs/reference/functions/new-poshbotcardresponse.md
@@ -15,7 +15,7 @@ Tells PoshBot to send a specially formatted response.
 ```
 New-PoshBotCardResponse [[-Type] <String>] [-DM] [[-Text] <String>] [[-Title] <String>]
  [[-ThumbnailUrl] <String>] [[-ImageUrl] <String>] [[-LinkUrl] <String>] [[-Fields] <Hashtable>]
- [[-Color] <String>] [<CommonParameters>]
+ [[-Color] <String>] [[-CustomData] <Object>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -218,8 +218,27 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -CustomData
+Any additional custom data you'd like to pass on.
+Useful for custom backends, in case you want to pass a specifically formatted response
+in the Data stream of the responses received by the backend.
+Any data sent here will be skipped by the built-in backends provided with PoshBot itself.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 9
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/new-poshbotconfiguration.md
+++ b/docs/reference/functions/new-poshbotconfiguration.md
@@ -692,7 +692,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/new-poshbotinstance.md
+++ b/docs/reference/functions/new-poshbotinstance.md
@@ -151,7 +151,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/new-poshbotscheduledtask.md
+++ b/docs/reference/functions/new-poshbotscheduledtask.md
@@ -176,7 +176,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/new-poshbotslackbackend.md
+++ b/docs/reference/functions/new-poshbotslackbackend.md
@@ -48,7 +48,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/new-poshbottextresponse.md
+++ b/docs/reference/functions/new-poshbottextresponse.md
@@ -91,7 +91,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/save-poshbotconfiguration.md
+++ b/docs/reference/functions/save-poshbotconfiguration.md
@@ -140,7 +140,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/start-poshbot.md
+++ b/docs/reference/functions/start-poshbot.md
@@ -147,7 +147,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/docs/reference/functions/stop-poshbot.md
+++ b/docs/reference/functions/stop-poshbot.md
@@ -101,7 +101,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is to allow custom data to be passed back to SendMessage in the Data stream of the response. Backend developers can leverage this to receive parsable data (i.e. REST body JSON) specific to their card response options. This will also be ignored by the included backends (Slack and Teams), so plugins/backends using this can create functions that will be cross-backend compatible.

## Related Issue
https://github.com/poshbotio/PoshBot/issues/88

## Motivation and Context
This is to allow custom data to be passed back to SendMessage in the Data stream of the response and be parsed by custom backends.

## How Has This Been Tested?
This has been tested during the buildout of the Google Chat backend I'm adding to [PSGSuite](https://github.com/scrthq/PSGSuite) currently. PSGSuite itself is tested in PS 5-Core via AppVeyor and Travis CI.

## Screenshots:
> Google Chat response

![image](https://user-images.githubusercontent.com/12724445/43562014-98dd6c68-95df-11e8-9947-a3236348a126.png)

> Slack response 

![image](https://user-images.githubusercontent.com/12724445/43562018-a537c9e0-95df-11e8-8de4-5514446d549e.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
