### PR TITLE
Add CardClicked to MessageType Enum for other backends to leverage if capable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   It is now possible to execute custom logic pre/post receiving a message from the chat network, pre/post command execution, and pre/post command response.
   These execution hooks can be used for centralized authentication logic, custom command whitelisting and blacklisting, response sanitation, or any number of other uses.
 
+- The `CustomData` parameter has been added to New-PoshBotCardResponse.
+  This enables custom backends and plugins to send additional data in a PoshBot Card Response.
+
+- `CardClicked` event type has been added to the `MessageType` enum.
+  This enables custom backends that support `CardClicked` events in interactive cards to use this event type with Event-trigger based commands.
+
 ### Fixed
 
 - Start-PoshBot with -AsJob switch now works correctly.

--- a/PoshBot/Classes/Enums.ps1
+++ b/PoshBot/Classes/Enums.ps1
@@ -62,6 +62,7 @@ enum ApprovalState {
 }
 
 enum MessageType {
+    CardClicked
     ChannelRenamed
     Message
     PinAdded
@@ -71,7 +72,6 @@ enum MessageType {
     ReactionRemoved
     StarAdded
     StarRemoved
-    CardClicked
 }
 
 enum MessageSubtype {

--- a/PoshBot/Classes/Enums.ps1
+++ b/PoshBot/Classes/Enums.ps1
@@ -71,6 +71,7 @@ enum MessageType {
     ReactionRemoved
     StarAdded
     StarRemoved
+    CardClicked
 }
 
 enum MessageSubtype {

--- a/docs/guides/triggers.md
+++ b/docs/guides/triggers.md
@@ -103,6 +103,7 @@ When one is found, the command will be executed.
 |-----------------|---------------|-------------|
 | Message         | ChannelJoined | A user joined a channel
 | Message         | ChannelLeft   | A user left a channel
+| CardClicked     | None          | A user clicked an interactive card
 | PinAdded        | None          | A user pinned an item
 | PinRemoved      | None          | A user unpinned an item
 | PresenceChange  | None          | A user's presence changed


### PR DESCRIPTION
Adds `CardClicked` to `enum MessageType` so that backends sending CardClicked events can leverage it on their custom backends.

## Description
Adds `CardClicked` to `enum MessageType` so that backends sending CardClicked events can leverage it on their custom backends.

## Related Issue
[Add CardClicked to `enum MessageType` #98](https://github.com/poshbotio/PoshBot/issues/98)

## Motivation and Context
Custom backends like Google Chat also send `CardClicked` events for interactive cards when buttons or images are clicked. This will allow the additional `MessageType` so that backends can leverage it natively

## How Has This Been Tested?
Tested with `PoshBot.GChat.Backend` in local.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. **N/A for this, tests don't exist (yet) for enums**
- [x] All new and existing tests passed.
