### PR TITLE
Pass the backend type into a Command -fixes #104

### DIFF
--- a/PoshBot/Classes/Command.ps1
+++ b/PoshBot/Classes/Command.ps1
@@ -69,7 +69,7 @@ class Command : BaseLogger {
     # }
 
     # Execute the command in a PowerShell job and return the running job
-    [object]Invoke([ParsedCommand]$ParsedCommand, [bool]$InvokeAsJob = $this.AsJob) {
+    [object]Invoke([ParsedCommand]$ParsedCommand, [bool]$InvokeAsJob = $this.AsJob, [string]$Backend) {
 
         $outer = {
             [cmdletbinding()]
@@ -96,6 +96,7 @@ class Command : BaseLogger {
                 ConfigurationDirectory = $options.ConfigurationDirectory
                 ParsedCommand = $options.ParsedCommand | Select-Object -ExcludeProperty $parsedCommandExcludes
                 OriginalMessage = $options.OriginalMessage
+                BackendType = $options.BackendType
             }
 
             & $cmd @namedParameters @positionalParameters
@@ -108,6 +109,7 @@ class Command : BaseLogger {
             CallingUserInfo = $ParsedCommand.CallingUserInfo
             OriginalMessage = $ParsedCommand.OriginalMessage.ToHash()
             ConfigurationDirectory = $script:ConfigurationDirectory
+            BackendType = $Backend
         }
         if ($this.FunctionInfo) {
             $options.Function = $this.FunctionInfo

--- a/PoshBot/Classes/CommandExecutor.ps1
+++ b/PoshBot/Classes/CommandExecutor.ps1
@@ -103,7 +103,7 @@ class CommandExecutor : BaseLogger {
 
                     # Kick off job and add to job tracker
                     $cmdExecContext.IsJob = $true
-                    $cmdExecContext.Job = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $true,$this._bot.Backend.Name)
+                    $cmdExecContext.Job = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $true,$this._bot.Backend.GetType().Name)
                     $this.LogDebug("Command [$($cmdExecContext.FullyQualifiedCommandName)] executing in job [$($cmdExecContext.Job.Id)]")
                     $cmdExecContext.Complete = $false
                 } else {
@@ -111,7 +111,7 @@ class CommandExecutor : BaseLogger {
                     # This should only be 'builtin' commands
                     try {
                         $cmdExecContext.IsJob = $false
-                        $hash = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $false,$this._bot.Backend.Name)
+                        $hash = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $false,$this._bot.Backend.GetType().Name)
                         $cmdExecContext.Complete = $true
                         $cmdExecContext.Ended = (Get-Date).ToUniversalTime()
                         $cmdExecContext.Result.Errors = $hash.Error

--- a/PoshBot/Classes/CommandExecutor.ps1
+++ b/PoshBot/Classes/CommandExecutor.ps1
@@ -103,7 +103,7 @@ class CommandExecutor : BaseLogger {
 
                     # Kick off job and add to job tracker
                     $cmdExecContext.IsJob = $true
-                    $cmdExecContext.Job = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $true)
+                    $cmdExecContext.Job = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $true,$this._bot.Backend.Name)
                     $this.LogDebug("Command [$($cmdExecContext.FullyQualifiedCommandName)] executing in job [$($cmdExecContext.Job.Id)]")
                     $cmdExecContext.Complete = $false
                 } else {
@@ -111,7 +111,7 @@ class CommandExecutor : BaseLogger {
                     # This should only be 'builtin' commands
                     try {
                         $cmdExecContext.IsJob = $false
-                        $hash = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $false)
+                        $hash = $cmdExecContext.Command.Invoke($cmdExecContext.ParsedCommand, $false,$this._bot.Backend.Name)
                         $cmdExecContext.Complete = $true
                         $cmdExecContext.Ended = (Get-Date).ToUniversalTime()
                         $cmdExecContext.Result.Errors = $hash.Error


### PR DESCRIPTION
## Description

Some systems like Teams will not automatically expand some output, like image links so sending them markdown instead of a plain link will correct this to enable this behaviour we need to be able to let other plugins know which backend it is talking to. Using $Global:PoshbotContext.BackendType will enable this.

I used the name of the backend as I didn't want to pass the whole Backend in when it wasn't really needed. 

## Related Issue
#104 


## How Has This Been Tested?
Tested with the xkcd plugin and using this code. Built locally and tested with Teams. I don't have a slack workspace to test it with but I can't see why it won't work. I'll submit a PR to PoshBot.xkcd as well with this fix.

```
if ($Global:PoshbotContext.BackendType -eq 'TeamsBackend') {
                    "![img]($($comic.img))"
                }
                else {
                    $Comic.img
                }
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
