### PR TITLE
Remove line breaks issue#109

### DIFF
--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -289,13 +289,12 @@ class Bot : BaseLogger {
     # Determine if message text is addressing the bot and should be
     # treated as a bot command
     [bool]IsBotCommand([Message]$Message) {
-        $parsedCommand = [CommandParser]::Parse($Message)
+        $firstWord = ($Message.Text -split ' ')[0]
         foreach ($prefix in $this._PossibleCommandPrefixes ) {
-        if ($parsedcommand.command -match "^$prefix") {
+            if ($firstWord -match "^$prefix") {
                 $this.LogDebug('Message is a bot command')
                 return $true
             }
-            else { $This.LogDebug("$($parsedcommand.command) didn't match $prefix")}
         }
         return $false
     }

--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -291,7 +291,7 @@ class Bot : BaseLogger {
      [bool]IsBotCommand([Message]$Message) {
         $parsedCommand = [CommandParser]::Parse($Message)
         foreach ($prefix in $this._PossibleCommandPrefixes ) {
-            if ($parsedCommand -match "^$prefix") {
+            if ($parsedCommand.command -match "^$prefix") {
                 $this.LogDebug('Message is a bot command')
                 return $true
             }

--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -288,10 +288,10 @@ class Bot : BaseLogger {
 
     # Determine if message text is addressing the bot and should be
     # treated as a bot command
-    [bool]IsBotCommand([Message]$Message) {
-        $firstWord = ($Message.Text -split ' ')[0]
+     [bool]IsBotCommand([Message]$Message) {
+        $parsedCommand = [CommandParser]::Parse($Message)
         foreach ($prefix in $this._PossibleCommandPrefixes ) {
-            if ($firstWord -match "^$prefix") {
+            if ($parsedCommand -match "^$prefix") {
                 $this.LogDebug('Message is a bot command')
                 return $true
             }

--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -289,12 +289,13 @@ class Bot : BaseLogger {
     # Determine if message text is addressing the bot and should be
     # treated as a bot command
     [bool]IsBotCommand([Message]$Message) {
-        $firstWord = ($Message.Text -split ' ')[0]
+        $parsedCommand = [CommandParser]::Parse($Message)
         foreach ($prefix in $this._PossibleCommandPrefixes ) {
-            if ($firstWord -match "^$prefix") {
+        if ($parsedcommand.command -match "^$prefix") {
                 $this.LogDebug('Message is a bot command')
                 return $true
             }
+            else { $This.LogDebug("$($parsedcommand.command) didn't match $prefix")}
         }
         return $false
     }


### PR DESCRIPTION
Switched to using the command parser to determine if a message is a bot command or not.

## Description


## Related Issue
Issue #109 

## How Has This Been Tested?
It's a small change, but it has fixed my issue. There may be a different way of handling this, but I see that the $parsedCommand is referred to in a few other places so I think it matches with the style.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
