### PR TITLE
Force module import to pick up changes

### DIFF
--- a/PoshBot/Classes/PluginManager.ps1
+++ b/PoshBot/Classes/PluginManager.ps1
@@ -464,7 +464,7 @@ class PluginManager : BaseLogger {
 
             # Get exported cmdlets/functions from the module and add them to the plugin
             # Adjust bot command behaviour based on metadata as appropriate
-            Import-Module -Name $manifestPath -Scope Local -Verbose:$false -WarningAction SilentlyContinue
+            Import-Module -Name $manifestPath -Scope Local -Verbose:$false -WarningAction SilentlyContinue -Force
             $moduleCommands = Microsoft.PowerShell.Core\Get-Command -Module $ModuleName -CommandType @('Cmdlet', 'Function') -Verbose:$false
             foreach ($command in $moduleCommands) {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Should use `-Force` when importing plugin modules

## Description
<!--- Describe your changes in detail -->
When using PoshBot in an interactive shell, the module remains loaded in the session even if a bot instance is stopped and later started. Plugin modules are imported into PoshBot's scope.

This means that after a plugin module has been imported once, subsequent calls to `Import-Module` will not do anything. If new plugin functions have been added PoshBot will not know about them after stopping and starting the instance.

Using `-Force` ensures that modules are always (re)loaded from disk.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/poshbotio/PoshBot/issues/117

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
