### PR TITLE
Prevent multiple execution of commands scheduled in the past

### DIFF
--- a/PoshBot/Classes/Logger.ps1
+++ b/PoshBot/Classes/Logger.ps1
@@ -27,6 +27,8 @@ class Logger {
         $this.Log([LogMessage]::new("Log level set to [$($this.LogLevel)]"))
     }
 
+    hidden Logger() { }
+
     # Create new log file or roll old log
     hidden [void]CreateLogFile() {
         if (Test-Path -Path $this.LogFile) {

--- a/PoshBot/Classes/ScheduledMessage.ps1
+++ b/PoshBot/Classes/ScheduledMessage.ps1
@@ -94,6 +94,10 @@ class ScheduledMessage {
         $currentDate = (Get-Date).ToUniversalTime()
         $difference = (New-TimeSpan $this.StartAfter $currentDate)
         $elapsedIntervals = [int][Math]::Ceiling($difference.TotalMilliseconds / $this.IntervalMS)
+        #Always move forward at least one interval
+        if ($elapsedIntervals -lt 1) {
+            $elapsedIntervals = 1
+        }
         $this.StartAfter = $this.StartAfter.AddMilliseconds($this.IntervalMS * $elapsedIntervals)
     }
 

--- a/PoshBot/Classes/ScheduledMessage.ps1
+++ b/PoshBot/Classes/ScheduledMessage.ps1
@@ -91,7 +91,10 @@ class ScheduledMessage {
     }
 
     [void]RecalculateStartAfter() {
-        $this.StartAfter = $this.StartAfter.AddMilliseconds($this.IntervalMS)
+        $currentDate = (Get-Date).ToUniversalTime()
+        $difference = (New-TimeSpan $this.StartAfter $currentDate)
+        $elapsedIntervals = [int][Math]::Ceiling($difference.TotalMilliseconds / $this.IntervalMS)
+        $this.StartAfter = $this.StartAfter.AddMilliseconds($this.IntervalMS * $elapsedIntervals)
     }
 
     [hashtable]ToHash() {

--- a/PoshBot/Classes/Scheduler.ps1
+++ b/PoshBot/Classes/Scheduler.ps1
@@ -34,10 +34,16 @@ class Scheduler : BaseLogger {
                 } else {
                     if (-not [string]::IsNullOrEmpty($sched.StartAfter)) {
                         $newSchedule = [ScheduledMessage]::new($sched.TimeInterval, $sched.TimeValue, $msg, $sched.Enabled, $sched.StartAfter.ToUniversalTime())
+
+                        if ($newSchedule.StartAfter -lt (Get-Date).ToUniversalTime()) {
+                            #Prevent reruns of commands initially scheduled at least one interval ago
+                            $newSchedule.RecalculateStartAfter()
+                        }
                     } else {
                         $newSchedule = [ScheduledMessage]::new($sched.TimeInterval, $sched.TimeValue, $msg, $sched.Enabled, (Get-Date).ToUniversalTime())
                     }
                 }
+
                 $newSchedule.Id = $sched.Id
                 $this.ScheduleMessage($newSchedule, $false)
             }

--- a/Tests/Unit/Classes/ScheduledMessages.tests.ps1
+++ b/Tests/Unit/Classes/ScheduledMessages.tests.ps1
@@ -152,7 +152,7 @@ InModuleScope PoshBot {
                 (New-TimeSpan $StartingValue $ScheduledMessage.StartAfter).TotalDays | Should Be 1
             }
 
-            It 'Should not schedule a run into the past' {
+            It 'Should not reschedule a run before the current time' {
                 $currentDate = (Get-Date).ToUniversalTime();
                 $startAfter = $currentDate.AddDays(-5);
                 $ScheduledMessage = [ScheduledMessage]::new($Interval, $TimeValue, $Message, $startAfter)
@@ -160,6 +160,15 @@ InModuleScope PoshBot {
                 $ScheduledMessage.RecalculateStartAfter();
 
                 $ScheduledMessage.StartAfter | Should Not BeLessThan $currentDate
+            }
+
+            It 'Should only move StartAfter value forward' {
+                $StartingValue = (Get-Date).AddDays($daysDifference).ToUniversalTime()
+                $ScheduledMessage = [ScheduledMessage]::new($Interval, $TimeValue, $Message, $StartingValue)
+
+                $ScheduledMessage.RecalculateStartAfter()
+
+                $ScheduledMessage.StartAfter | Should Be $StartingValue.AddDays(1)
             }
         }
 

--- a/Tests/Unit/Classes/ScheduledMessages.tests.ps1
+++ b/Tests/Unit/Classes/ScheduledMessages.tests.ps1
@@ -143,13 +143,23 @@ InModuleScope PoshBot {
         }
 
         Context "Method: RecalculateStartAfter()" {
-            $ScheduledMessage = [ScheduledMessage]::new($Interval, $TimeValue, $Message, (Get-Date))
-
             It 'Should increase the StartAfter property by IntervalMS' {
+                $ScheduledMessage = [ScheduledMessage]::new($Interval, $TimeValue, $Message, (Get-Date))
+
                 $StartingValue = $ScheduledMessage.StartAfter
                 $ScheduledMessage.RecalculateStartAfter()
 
                 (New-TimeSpan $StartingValue $ScheduledMessage.StartAfter).TotalDays | Should Be 1
+            }
+
+            It 'Should not schedule a run into the past' {
+                $currentDate = (Get-Date).ToUniversalTime();
+                $startAfter = $currentDate.AddDays(-5);
+                $ScheduledMessage = [ScheduledMessage]::new($Interval, $TimeValue, $Message, $startAfter)
+
+                $ScheduledMessage.RecalculateStartAfter();
+
+                $ScheduledMessage.StartAfter | Should Not BeLessThan $currentDate
             }
         }
 

--- a/Tests/Unit/Classes/Scheduler.tests.ps1
+++ b/Tests/Unit/Classes/Scheduler.tests.ps1
@@ -95,13 +95,9 @@ InModuleScope PoshBot {
 
                 $originalStartAfter = $futureSchedule['StartAfter']
 
-                #Write-Error ($futureSchedule | ConvertTo-Json)
-
                 $Storage.SaveConfig('schedules', @{ sched_test = $futureSchedule })
 
                 $scheduler = [Scheduler]::New($Storage, $Logger)
-
-                #Write-Error ($scheduler.Schedules | ConvertTo-Json)
 
                 ($scheduler.Schedules."$($futureSchedule.Id)").StartAfter | Should Be $originalStartAfter
             }

--- a/Tests/Unit/Classes/Scheduler.tests.ps1
+++ b/Tests/Unit/Classes/Scheduler.tests.ps1
@@ -1,0 +1,91 @@
+using module 'PoshBot'
+
+
+class MockLogger : Logger {
+    MockLogger() {
+    }
+
+    hidden [void]CreateLogFile() {
+        Write-Debug -Message "[Logger:Logger] Creating log file [$($this.LogFile)]"
+    }
+
+    [void]Log([LogMessage]$Message) {
+        Write-Debug -Message $Message.ToJson()
+    }
+
+    [void]Log([LogMessage]$Message, [string]$LogFile, [int]$MaxLogSizeMB, [int]$MaxLogsToKeep) {
+        Write-Debug -Message $Message.ToJson()
+    }
+
+    hidden [void]WriteLine([string]$Message) {
+        Write-Debug -Message $Message
+    }
+
+    hidden [void]RollLog([string]$LogFile, [bool]$Always) {
+    }
+
+    hidden [void]RollLog([string]$LogFile, [bool]$Always, $MaxLogSize, $MaxFilesToKeep) {
+    }
+}
+
+class MockStorageProvider : StorageProvider {
+    [string]$ConfigPath
+
+    [hashtable]$Config
+
+    MockStorageProvider([Logger]$Logger) : base($Logger) {
+        $this.Config = @{}
+    }
+
+    [hashtable]GetConfig([string]$ConfigName) {
+        if ($this.Config[$ConfigName]) {
+            return $this.Config[$ConfigName]
+        }
+        else {
+            return $null
+        }
+    }
+
+    [void]SaveConfig([string]$ConfigName, [hashtable]$Config) {
+        $this.Config[$ConfigName] = $Config
+    }
+}
+
+InModuleScope PoshBot {
+
+    Describe Scheduler {
+        $Logger = [MockLogger]::New()
+        $Storage = [MockStorageProvider]::New($Logger)
+
+        $Schedule = @{
+            sched_test = @{
+                StartAfter = (Get-Date).ToUniversalTime().AddDays(-5)
+                Once = $False
+                TimeValue = 1
+                IntervalMS = 86400000
+                Id = New-Guid
+                TimeInterval = 'Days'
+                Enabled = $True
+                Message = @{
+                  Id = ''
+                  Text = '!help'
+                  To = ''
+                  From = ''
+                  Type = 'Message'
+                  Subtype = 'None'
+                }
+            }
+        }
+
+        $Storage.SaveConfig('schedules', $Schedule)
+
+        Context 'Methods: LoadState()' {
+            It 'Schedules should not be loaded as triggered' {
+                $scheduler = [Scheduler]::New($Storage, $Logger)
+
+                $scheduler.GetTriggeredMessages().Count | Should Be 0
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Changes `ScheduledMessage.RecalculateStartAfter()` logic to advance `StartAfter` until it moves past the current date
    * A side effect of the implementation is that all `StartAfter` times are expected to be UTC
* Changes `Scheduler.LoadState` to call `RecalculateStartAfter()` on loaded schedules whose `StartAfter` is before the current time
* Adds `hidden` parameterless constructor for `Logger`, to enable some mocking
    * There's probably a better way to do that--I'm not real familiar with PowerShell's testing and mocking libraries

## Related Issue

#120 

## Motivation and Context

If a command was originally scheduled several months ago and the bot is restarted, a very large number of executions will occur very quickly.  Depending on the command scheduled, this may prove problematic.

## How Has This Been Tested?

Added unit tests to `ScheduledMessages.tests.ps1` to check the behavior of `RecalculateStartAfter()` with dates in the future and the past.

Added unit tests (and some hacky mocks) in `Scheduler.tests.ps1` to check the behavior of `Scheduler.LoadState()` when a schedule with a `StartAfter` in the past is loaded.

Manually started a bot and ran `!newschedule --command 'help' --interval minutes --value 5 --startafter '2018-10-01 12:25pm'` and verified that only one response was produced immediately.  Restarted the bot and verified that no responses were produced on schedule load.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
    - I think?  I don't do a lot in PowerShell on a day-to-day basis, so I may have inadvertently missed something.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
