### PR TITLE
Enable running multiple versions of PoshBot side-by-side

### DIFF
--- a/PoshBot/Classes/Command.ps1
+++ b/PoshBot/Classes/Command.ps1
@@ -77,6 +77,8 @@ class Command : BaseLogger {
                 [hashtable]$Options
             )
 
+            Import-Module -Name $Options.PoshBotManifestPath -Force -Verbose:$false -WarningAction SilentlyContinue -ErrorAction Stop
+
             Import-Module -Name $Options.ManifestPath -Scope Local -Force -Verbose:$false -WarningAction SilentlyContinue
 
             $cmd = $Options.Function
@@ -110,6 +112,7 @@ class Command : BaseLogger {
             OriginalMessage = $ParsedCommand.OriginalMessage.ToHash()
             ConfigurationDirectory = $script:ConfigurationDirectory
             BackendType = $Backend
+            PoshBotManifestPath = (Join-Path -Path $script:moduleBase -ChildPath "PoshBot.psd1")
         }
         if ($this.FunctionInfo) {
             $options.Function = $this.FunctionInfo

--- a/PoshBot/Public/Start-PoshBot.ps1
+++ b/PoshBot/Public/Start-PoshBot.ps1
@@ -92,10 +92,11 @@ function Start-PoshBot {
                 $sb = {
                     param(
                         [parameter(Mandatory)]
-                        [hashtable]$Configuration
+                        [hashtable]$Configuration,
+                        [string]$PoshBotManifestPath
                     )
 
-                    Import-Module PoshBot -ErrorAction Stop
+                    Import-Module $PoshBotManifestPath -ErrorAction Stop
 
                     try {
                         $tempConfig = New-PoshBotConfiguration
@@ -127,8 +128,9 @@ function Start-PoshBot {
 
                 $instanceId = (New-Guid).ToString().Replace('-', '')
                 $jobName = "PoshBot_$instanceId"
+                $poshBotManifestPath = (Join-Path -Path $PSScriptRoot -ChildPath "PoshBot.psd1")
 
-                $job = Start-Job -ScriptBlock $sb -Name $jobName -ArgumentList $Configuration.ToHash()
+                $job = Start-Job -ScriptBlock $sb -Name $jobName -ArgumentList $Configuration.ToHash(),$poshBotManifestPath
 
                 # Track the bot instance
                 $botTracker = @{

--- a/PoshBot/Task/StartPoshBot.ps1
+++ b/PoshBot/Task/StartPoshBot.ps1
@@ -1,5 +1,3 @@
-#requires -modules PoshBot
-
 [cmdletbinding()]
 param(
     [parameter(Mandatory)]
@@ -16,6 +14,5 @@ param(
     })]
     [string]$Path
 )
-
-Import-Module PoshBot -Force -ErrorAction Stop
+Import-Module "$PSScriptRoot\..\PoshBot.psd1" -Force -ErrorAction Stop
 Start-PoshBot -Path $Path


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This makes PoshBot more "portable" and makes it possible to run multiple versions side-by-side

## Description
<!--- Describe your changes in detail -->
Instead of relying on `Import-Module PoshBot` to load a module found via $env:PSModulePath we explicitly specify which module manifest to load. That way you can have PoshBot installed in your system while also working on a newer version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
