### PR TITLE
Adding array of special character, and escaping them

### DIFF
--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -32,6 +32,8 @@ class Bot : BaseLogger {
 
     hidden [System.Collections.Arraylist] $_PossibleCommandPrefixes = (New-Object System.Collections.ArrayList)
 
+    hidden [System.Collections.ArrayList] $_regexSpecialCharacters = @('[','\','^','$','.','|','?','*','+','(', ')','{', '}')
+
     hidden [MiddlewareConfiguration] $_Middleware
 
     hidden [bool]$LazyLoadComplete = $false
@@ -291,7 +293,12 @@ class Bot : BaseLogger {
      [bool]IsBotCommand([Message]$Message) {
         $parsedCommand = [CommandParser]::Parse($Message)
         foreach ($prefix in $this._PossibleCommandPrefixes ) {
-            if ($parsedCommand.command -match "^$prefix") {
+            if ($prefix -in $this._regexSpecialCharacters) {
+                $regexEscape = '\'
+            } else {
+                $regexEscape = $null
+            }
+            if ($parsedCommand.command -match "^$regexEscape$prefix") {
                 $this.LogDebug('Message is a bot command')
                 return $true
             }
@@ -519,7 +526,12 @@ class Bot : BaseLogger {
             $firstWord = ($Message.Text -split ' ')[0]
 
             foreach ($prefix in $this._PossibleCommandPrefixes) {
-                if ($firstWord -match "^$prefix") {
+                if ($prefix -in $this._regexSpecialCharacters) {
+                    $regexEscape = '\'
+                } else {
+                    $regexEscape = $null
+                }
+                if ($firstWord -match "^$regexEscape$prefix") {
                     $Message.Text = $Message.Text.TrimStart($prefix).Trim()
                 }
             }


### PR DESCRIPTION
## Description

Adding array of special character, and escaping them

Basically, some characters are regex special characters... '.' is a wildcard... so it was matching on literally everything. Adding an escape character (only when it's needed) allows the match to be literal.

## Related Issue

This should fix issue #124.

## Motivation and Context

Allows using desired prefix characters, such as .

`. about`

## How Has This Been Tested?

Tested using standard (!) prefixes, and indicated issue prefix (.), and other random ones (a)

Also tested to ensure that string prefixes (bender) still work

## Screenshots (if appropriate):

_Testing with ! prefix_

![test-](https://user-images.githubusercontent.com/6955786/46773852-0c30a500-cd5c-11e8-98d5-3efa1ac0671f.PNG)

_Testing with . prefix_

![test-period](https://user-images.githubusercontent.com/6955786/46773863-12bf1c80-cd5c-11e8-81bb-8cac370a47ae.PNG)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. _(erm 45/53 passed, but they all failures seemed to be 'Path' related.)_
