### PR TITLE
Use module-qualified cmdlet names when invoking plugins

### DIFF
--- a/PoshBot/Classes/Plugin.ps1
+++ b/PoshBot/Classes/Plugin.ps1
@@ -17,16 +17,6 @@ class PluginDisabled : PluginException {
     PluginDisabled([string]$Message) : base($Message) {}
 }
 
-# Represents a fully qualified module command
-class ModuleCommand {
-    [string]$Module
-    [string]$Command
-
-    [string]ToString() {
-        return "$($this.Module)\$($this.Command)"
-    }
-}
-
 class Plugin : BaseLogger {
 
     # Unique name for the plugin

--- a/PoshBot/Plugins/Builtin/Public/Get-CommandHelp.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Get-CommandHelp.ps1
@@ -132,7 +132,7 @@ function Get-CommandHelp {
             }
             if ($HelpParams.Keys.Count -gt 0) {
                 $fullVersionName = "$($result.FullCommandName)`:$($result.Version)"
-                $manString = Get-Help $Bot.PluginManager.Commands[$fullVersionName].ModuleCommand @HelpParams | Out-String
+                $manString = Get-Help $Bot.PluginManager.Commands[$fullVersionName].ModuleQualifiedCommand @HelpParams | Out-String
                 $result | Add-Member -MemberType NoteProperty -Name Manual -Value "`n$manString"
             }
             $respParams.Text = ($result | Format-List | Out-String -Width 150).Trim()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I wanted to use `start` cmdlet name in a plugin but discovered that command execution jobs never finish executing. Turns out that `start` was being resolved as `Start-Process` by PowerShell. PoshBot should use module-qualified cmdlet names when invoking plugin commands to ensure that the right cmdlet is called regardless of aliases.

https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_command_precedence?view=powershell-6#qualified-names

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Enables usage of cmdlet names in plugins which might be hidden by an alias e.g. `start` (a default alias for `Start-Process`)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
