### PR TITLE
Fixes poshbotio/PoshBot#131

### DIFF
--- a/PoshBot/Public/New-PoshBotConfiguration.ps1
+++ b/PoshBot/Public/New-PoshBotConfiguration.ps1
@@ -308,6 +308,7 @@ function New-PoshBotConfiguration {
     $config.DisallowDMs = ($DisallowDMs -eq $true)
     $config.FormatEnumerationLimitOverride = $FormatEnumerationLimitOverride
     if ($ChannelRules.Count -ge 1) {
+        $config.ChannelRules = $null
         foreach ($item in $ChannelRules) {
             $config.ChannelRules += [ChannelRule]::new($item.Channel, $item.IncludeCommands, $item.ExcludeCommands)
         }


### PR DESCRIPTION
Added a fix for issue #131 

## Description
Added a single line that wipes out the default channel rule when adding others

## Related Issue
#131

## Motivation and Context
Able to restrict commands in slack channels

## How Has This Been Tested?
Confirmed that when adding rules the created configuration did not include the default channel rule.
Added rules and tested in own slack workspace.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
