### PR TITLE
Fix approval group logging and approval group being bypassed

### DIFF
--- a/PoshBot/Classes/CommandExecutor.ps1
+++ b/PoshBot/Classes/CommandExecutor.ps1
@@ -317,19 +317,18 @@ class CommandExecutor : BaseLogger {
                     $inApprovalGroup = (Compare-Object @compareParams).Count -gt 0
 
                     $Context.ApprovalState = [ApprovalState]::Pending
-                    $this.LogDebug("Execution context ID [$($Context.Id)] needs approval from group(s) [$($approvalGroups.Name -join ', ')]")
+                    $this.LogDebug("Execution context ID [$($Context.Id)] needs approval from group(s) [$(($compareParams.ReferenceObject) -join ', ')]")
 
-                    if ($approvalConfig.PeerApproval) {
-                        $this.LogDebug("Execution context ID [$($Context.Id)] needs peer approval")
-                    }
-
-                    if ($approvalConfig.PeerApproval -and $inApprovalGroup) {
+                    if ($inApprovalGroup) {
+                        if ($approvalConfig.PeerApproval) {
+                            $this.LogDebug("Execution context ID [$($Context.Id)] needs peer approval")
+                        } else {
+                            $this.LogInfo("Peer Approval not needed to execute context ID [$($Context.Id)]")
+                        }
+                        return $approvalConfig.PeerApproval
+                    } else {
                         $this.LogInfo("Approval needed to execute context ID [$($Context.Id)]")
                         return $true
-                    } else {
-                        $this.LogInfo("Approval not needed to execute context ID [$($Context.Id)]")
-                        $Context.ApprovalState = [ApprovalState]::Approved
-                        return $false
                     }
                 }
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
1. There is a `LogDebug` Message that is logging the wrong group in the message. It's currently logging the group that the user is a member of and not the approval groups that can approve the command.
1. The approval logic is being bypassed for users in groups that are assigned a role that has permissions to run a command (BUT, it works if that user is a member of both the group that can execute the command _and_ the approval group assigned)

## Description
Fixed the LogDebug line that was showing the Groups that the user belonged in, and not the approval groups.

Next, changed the logic on the Approval Group check to say _Hey, are you in the ApprovalGroup? Yeah? Ok, is Peerapproval enabled? Yeah? Then we better get a buddy to approve. Otherwise, you don't need approval, let's execute!_

Conversely, _Oh you aren't in the Approval Group? Then you definitly need to have approval to run this command._

The reason this logic works is because its already been determined that you have _permission_ to execute this command before the `ApprovalNeeded` function is even called. Meaning, you wouldn't have gotten here if you didn't, so we're just trying to figure out if:

1. There is an approval needed for this command?
1. Are you in the approval group or not?
1. Is peer approval required?

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/poshbotio/PoshBot/issues/153


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This bug allows any user with permission to execute a command even when the command has an _approval configuration_ setup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We tested by running through the scenarios layed out in the corresponding issue link.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
