### PR TITLE
Removal of the trailing ?? from Teams

### DIFF
--- a/PoshBot/Implementations/Teams/TeamsBackend.ps1
+++ b/PoshBot/Implementations/Teams/TeamsBackend.ps1
@@ -73,7 +73,7 @@ class TeamsBackend : Backend {
                             # This will show up in the text of the message received. We don't need it
                             # so strip it out.
                             if ($teamsMessage.text)    {
-                                $msg.Text = $teamsMessage.text.Replace("<at>$($this.Connection.Config.BotName)</at> ", '')
+                                $msg.Text = $teamsMessage.text.Replace("<at>$($this.Connection.Config.BotName)</at> ", '').Replace('\?\?$','')
                             }
 
                             if ($teamsMessage.from) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When a space is at the end of the message, Teams replaces that with ??

## Related Issue
https://github.com/poshbotio/PoshBot/issues/164
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This allows the use of suggested actions in Teams. Prior, the bot would respond with Status?? unknown.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Sent command to bot with space  in middle and end of the command. Only the end ?? got removed.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X] All new and existing tests passed.
