### PR TITLE
Patch 2

### DIFF
--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -299,14 +299,15 @@ class Bot : BaseLogger {
      [bool]IsBotCommand([Message]$Message) {
         $firstWord = ($Message.Text -split ' ')[0].Trim()
         foreach ($prefix in $this._PossibleCommandPrefixes ) {
+            if($prefix -ne '*'){
             $prefix = [regex]::Escape($prefix)
+            }
             if ($firstWord -match "^$prefix") {
                 $this.LogDebug('Message is a bot command')
                 return $true
             }
         }
         return $false
-    }
 
     # Pull message(s) off queue and pass to handler
     [void]ProcessMessageQueue() {
@@ -526,7 +527,11 @@ class Bot : BaseLogger {
         if (-not [string]::IsNullOrEmpty($Message.Text)) {
             $firstWord = ($Message.Text -split ' ')[0].Trim()
             foreach ($prefix in $this._PossibleCommandPrefixes) {
-                $prefixEscaped = [regex]::Escape($prefix)
+                If($prefix -ne '*'){
+                    $prefixEscaped = [regex]::Escape($prefix)
+                }Else{
+                    $prefixEscaped = $prefix
+                }
                 if ($firstWord -match "^$prefixEscaped") {
                     $Message.Text = $Message.Text.TrimStart($prefix).Trim()
                 }

--- a/PoshBot/Classes/Bot.ps1
+++ b/PoshBot/Classes/Bot.ps1
@@ -308,7 +308,7 @@ class Bot : BaseLogger {
             }
         }
         return $false
-
+    }
     # Pull message(s) off queue and pass to handler
     [void]ProcessMessageQueue() {
         while ($this.MessageQueue.Count -ne 0) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow * to used as empty prefix
## Description
<!--- Describe your changes in detail -->
In Teams, we already have to use @ to call the bot,so I didn't want to use an additional prefix like !. I'm not sure where in the code your not allowing $null to be a prefix so I removed * from [regex]::escape(). 
## Related Issue
https://github.com/poshbotio/PoshBot/issues/163
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested by not using a prefix like !. 
@poshbot Status
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
poshbot 11.5
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1231453/55198963-84feae80-518e-11e9-9665-853c4f4389e3.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
