### PR TITLE
Add additional objects to !slap

### DIFF
--- a/PoshBot/Plugins/Builtin/Public/Slap.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Slap.ps1
@@ -26,7 +26,7 @@ function Slap {
             item = 'large trout'
             thumbnail = 'https://upload.wikimedia.org/wikipedia/commons/1/16/Rainbow_trout_transparent.png'
         }
-        foamfinger = @{
+        finger = @{
             item = 'giant foam finger'
             thumbnail = 'https://images.vexels.com/media/users/3/153013/isolated/preview/517c07f5ff433028345e10b138870119-american-foam-finger-design-element-by-vexels.png'
         }
@@ -34,9 +34,13 @@ function Slap {
             item = 'mechanical keyboard'
             thumbnail = 'https://cdn.pixabay.com/photo/2013/07/13/11/50/computer-158770_960_720.png'
         }
-        foamsword = @{
+        sword = @{
             item = 'foam sword'
             thumbnail = 'https://upload.wikimedia.org/wikipedia/commons/2/2b/Foamswordofrecall.png'
+        }
+        noodles = @{
+            item = 'pile of noodles'
+            thumbnail = 'http://pngimg.com/uploads/noodle/noodle_PNG33.png'
         }
     }
     $choice = if ($PSBoundParameters.ContainsKey('Object') -and $objects.ContainsKey($Object)) {

--- a/PoshBot/Plugins/Builtin/Public/Slap.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Slap.ps1
@@ -1,9 +1,11 @@
 function Slap {
     <#
     .SYNOPSIS
-        Slap a user with a large trout
+        Slap a user with an object
     .PARAMETER User
         The user that will be slapped
+    .PARAMETER Object
+        The object to slap the user with. Defaults to a random object.
     .EXAMPLE
         !slap --user jaap
 
@@ -39,7 +41,7 @@ function Slap {
             thumbnail = 'https://upload.wikimedia.org/wikipedia/commons/2/2b/Foamswordofrecall.png'
         }
         noodles = @{
-            item = 'pile of noodles'
+            item = 'pile of wet noodles'
             thumbnail = 'http://pngimg.com/uploads/noodle/noodle_PNG33.png'
         }
     }

--- a/PoshBot/Plugins/Builtin/Public/Slap.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Slap.ps1
@@ -6,15 +6,45 @@ function Slap {
         The user that will be slapped
     .EXAMPLE
         !slap --user jaap
+
+    .EXAMPLE
+        !slap jaap foamfinger
     #>
     [cmdletbinding()]
     param(
         [parameter(Mandatory)]
-        $Bot,    
+        $Bot,
 
         [parameter(Mandatory, Position = 0)]
-        [string] $User
-    )
+        [string] $User,
 
-    New-PoshBotCardResponse -Type Normal -Text "slaps $User around a bit with a large trout" -ThumbnailUrl 'http://i.imgur.com/W1Dkemu.jpg'
+        [parameter(Position = 1)]
+        [string] $Object
+    )
+    $objects = @{
+        trout = @{
+            item = 'large trout'
+            thumbnail = 'https://upload.wikimedia.org/wikipedia/commons/1/16/Rainbow_trout_transparent.png'
+        }
+        foamfinger = @{
+            item = 'giant foam finger'
+            thumbnail = 'https://images.vexels.com/media/users/3/153013/isolated/preview/517c07f5ff433028345e10b138870119-american-foam-finger-design-element-by-vexels.png'
+        }
+        keyboard = @{
+            item = 'mechanical keyboard'
+            thumbnail = 'https://cdn.pixabay.com/photo/2013/07/13/11/50/computer-158770_960_720.png'
+        }
+        foamsword = @{
+            item = 'foam sword'
+            thumbnail = 'https://upload.wikimedia.org/wikipedia/commons/2/2b/Foamswordofrecall.png'
+        }
+    }
+    $choice = if ($PSBoundParameters.ContainsKey('Object') -and $objects.ContainsKey($Object)) {
+        $objects[$Object]
+    }
+    else {
+        $random = $objects.Keys | Get-Random
+        $objects[$random]
+    }
+    New-PoshBotCardResponse -Type Normal -Text "slaps $User around a bit with a $($choice['item'])" -ThumbnailUrl $choice['thumbnail']
 }

--- a/PoshBot/Plugins/Builtin/Public/Slap.ps1
+++ b/PoshBot/Plugins/Builtin/Public/Slap.ps1
@@ -9,8 +9,12 @@ function Slap {
     .EXAMPLE
         !slap --user jaap
 
+        Slaps Jaap with a random object
+
     .EXAMPLE
-        !slap jaap foamfinger
+        !slap jaap finger
+
+        Slaps Jaap with a giant foam finger
     #>
     [cmdletbinding()]
     param(

--- a/docs/reference/commands/Slap.md
+++ b/docs/reference/commands/Slap.md
@@ -26,6 +26,11 @@ Slap -Bot <Object> [-User] <String> [[-Object] <String>] [<CommonParameters>]
 !slap --user jaap
 ```
 
+### EXAMPLE 2
+```
+!slap jaap foamfinger
+```
+
 ## PARAMETERS
 
 ### -Bot

--- a/docs/reference/commands/Slap.md
+++ b/docs/reference/commands/Slap.md
@@ -13,7 +13,7 @@ Slap a user with a large trout
 ## SYNTAX
 
 ```
-Slap -Bot <Object> [-User] <String> [<CommonParameters>]
+Slap -Bot <Object> [-User] <String> [[-Object] <String>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -53,6 +53,21 @@ Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Object
+{{ Fill Object Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
## Description
Adds the following objects to the `!slap` command:
- giant foam finger
- mechanical keyboard
- pile of wet noodles
- foam sword

Added the additional `Object` parameter to `!slap` to specify an object. Defaults to a random object if the parameter is not specified or the object is not in the list of current objects.

Also replaced the default `large trout` thumbnail with something more crisp.

## Related Issue
N/A

## Motivation and Context
More slap options make everyone happy!

## How Has This Been Tested?
Lots of slapping

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/12724445/66287973-35b3dc00-e89d-11e9-9b00-c6f31a1c01d4.png)

![image](https://user-images.githubusercontent.com/12724445/66288026-63992080-e89d-11e9-9b9d-8b0db38eeb3b.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation. (kinda)
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
