### PR TITLE
Adding #required modules to build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,6 @@
+#Requires -Module @{ModuleName = 'BuildHelpers' ; RequiredVersion = '2.0.11'}
+#Requires -Module @{ModuleName = 'platyPS' ; RequiredVersion = '0.14.0';}
+#Requires -Module @{ModuleName = 'Pester' ; RequiredVersion = '4.8.1';}
 
 [cmdletbinding(DefaultParameterSetName = 'task')]
 param(

--- a/build.ps1
+++ b/build.ps1
@@ -1,3 +1,4 @@
+#Requires -Module @{ModuleName = 'psake' ; RequiredVersion = '4.9.0'}
 #Requires -Module @{ModuleName = 'BuildHelpers' ; RequiredVersion = '2.0.11'}
 #Requires -Module @{ModuleName = 'platyPS' ; RequiredVersion = '0.14.0';}
 #Requires -Module @{ModuleName = 'Pester' ; RequiredVersion = '4.8.1';}


### PR DESCRIPTION
I added #requires to help people building the module.
PSModuleVersions are from todays date, 11 october 2019.
Will aid people to build from source more easily I suspect.

## Description
Added the needed modules to compile, test, analyze etc the module with the build.ps1 script.

## Motivation and Context
I got annoyed that I didn't have all the needed modules installed on a system. And instead of having to track down the proper modules I'd rather have the build script just tell me what I'm missing.
Though it might not be the what you'd like to have contribute. Feel free to decline and throw away the PR as you see fit.

## How Has This Been Tested?
Tested all build.ps1 tasks no errors.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Quality of Life fix (Improves the quality of life but doesn't do all that much to the project itself?)

## Checklist:
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
