### PR TITLE
WIP: PSSlack threaded responses

### DIFF
--- a/PoshBot/Implementations/Slack/SlackBackend.ps1
+++ b/PoshBot/Implementations/Slack/SlackBackend.ps1
@@ -419,8 +419,13 @@ class SlackBackend : Backend {
                         } else {
                             $attParams.Text = [string]::Empty
                         }
+                        #hack for threads
+                        $ThreadSplat = @{}
+                        if ($Response.OriginalMessage.RawMessage.thread_ts){
+                            $ThreadSplat.Thread = $($Response.OriginalMessage.RawMessage.thread_ts)
+                        }
                         $att = New-SlackMessageAttachment @attParams
-                        $msg = $att | New-SlackMessage -Channel $sendTo -AsUser
+                        $msg = $att | New-SlackMessage -Channel $sendTo -AsUser @ThreadSplat
                         $this.LogDebug("Sending card response back to Slack channel [$sendTo]", $att)
                         $msg | Send-SlackMessage -Token $this.Connection.Config.Credential.GetNetworkCredential().Password -Verbose:$false > $null
                     }

--- a/PoshBot/PoshBot.psd1
+++ b/PoshBot/PoshBot.psd1
@@ -53,7 +53,8 @@ PowerShellVersion = '5.0'
 # Modules that must be imported into the global environment prior to importing this module
 RequiredModules = @(
     @{ModuleName = 'Configuration'; ModuleVersion = '1.3.1'}
-    @{ModuleName = 'PSSlack';       ModuleVersion = '1.0.2'}
+    # Requires unpublished version of PSSlack
+    # @{ModuleName = 'PSSlack';       ModuleVersion = '1.0.2'}
 )
 
 # Assemblies that must be loaded prior to importing this module


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR is looking to add support for the feature requested in #228 for threaded responses from Poshbot with a slack backend.

## Description
<!--- Describe your changes in detail -->
The quick work around is that there is a  check inside the `SendMessage` function that `$Response.OriginalMessage.RawMessage.thread_ts` is present. This is ran inside the Slack Backend, but could probably be put into the Response class. This change will require that this change from PSSlack be merged. https://github.com/RamblingCookieMonster/PSSlack/pull/119 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#228 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I was personally looking for a way to keep PoshBot messages threaded and didn't find any documentation for current support. I noticed the open issue, and thought it would be fun. This can help users cut down on noise in a channel without loosing the transparency of working with a bot. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Setup a Test bot on a personal slack channel and tested threaded/Non threaded built-in, Giphy and XKCD plugin. Also tested in DMs as well. Tested various response types to ensure that text/card/url/file all respond as expected. Still having an issue with threaded file uploads.

## Screenshots (if appropriate):
Previous non working state:
Any message to a thread is returned to the channel.
![before](https://user-images.githubusercontent.com/13426972/123497671-5b0eed80-d61e-11eb-8a4d-8b09fa2de686.PNG)

working state:
Keyword in thread is returned to thread. Keyword in Channel is returned to channel. Keyword in DM is only sent to DM
![after](https://user-images.githubusercontent.com/13426972/123497724-b17c2c00-d61e-11eb-9e15-f6ba11a4987b.PNG)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
