### PR TITLE
(#241) Add additional Discord channel types

### DIFF
--- a/PoshBot/Implementations/Discord/DiscordChannel.ps1
+++ b/PoshBot/Implementations/Discord/DiscordChannel.ps1
@@ -1,11 +1,15 @@
 enum DiscordChannelType {
-    GUILD_TEXT     = 0
-    DM             = 1
-    GUILD_VOICE    = 2
-    GROUP_DM       = 3
-    GUILD_CATEGORY = 4
-    GUILD_NEWS     = 5
-    GUILD_STORE    = 6
+    GUILD_TEXT           = 0
+    DM                   = 1
+    GUILD_VOICE          = 2
+    GROUP_DM             = 3
+    GUILD_CATEGORY       = 4
+    GUILD_NEWS           = 5
+    GUILD_STORE          = 6
+    GUILD_NEWS_THREAD    = 10
+    GUILD_PUBLIC_THREAD  = 11
+    GUILD_PRIVATE_THREAD = 12
+    GUILD_STAGE_VOICE    = 13
 }
 
 class DiscordChannel : Room {


### PR DESCRIPTION
## Description

This PR adds four additional channel types to the Discord implementation:

* `GUILD_NEWS_THREAD`
* `GUILD_PUBLIC_THREAD`
* `GUILD_PRIVATE_THREAD`
* `GUILD_STAGE_VOICE`

Adding `GUILD_STAGE_VOICE` resolves #241 and the others are included for completeness.

## Related Issue

#241 

## Motivation and Context

This enables PoshBot to connect to servers that happen to have temporary channels, such as [Stages](https://support.discord.com/hc/en-us/articles/1500005513722-Stage-Channels-FAQ) or Threads at the time that it connects to the server.

## How Has This Been Tested?

I have made this change to PoshBot on my local machine, and it resolved my issue connecting to the [Chocolatey server](https://ch0.co/community) which happens to currently have a Stage channel running.

For completeness, I also tested against a server without a Stage running to ensure it didn't affect that (not that I expected editing an enum to have affected that.)

## Screenshots (if appropriate):

N/A - There are screenshots of the issue this fixes in #241 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document. 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.